### PR TITLE
Remove utc to localtime conversion from daily_plot.py

### DIFF
--- a/scripts/daily_plot.py
+++ b/scripts/daily_plot.py
@@ -19,7 +19,7 @@ def get_data(now=None):
     conn = sqlite3.connect(DB_PATH)
     if now is None:
         now = datetime.now()
-    df = pd.read_sql_query(f"SELECT * from detections WHERE Date = DATE('{now.strftime('%Y-%m-%d')}', 'localtime')",
+    df = pd.read_sql_query(f"SELECT * from detections WHERE Date = DATE('{now.strftime('%Y-%m-%d')}')",
                            conn)
 
     # Convert Date and Time Fields to Panda's format


### PR DESCRIPTION
The addition of handling date cutover for updating charts introduced a bug on systems whose timezones are behind UTC. Specifically, the 'localtime' modifier to DATE() attempts to interpret the date to the left as UTC, and convert to localtime. The result is that in timezones behind UTC, the date selected is always 1 earlier than intended.

No timezone conversion is needed. We need a date for today, or 24h ago, to match for the where clause in the query. Since the data in the DB is in localtime, and the output of python datetime is also in localtime, it's good enough to just turn it into a YYYY-MM-DD without any timezone conversion at all.

Here's a demonstration of calling DATE() in various ways in North America EST:

sqlite> select DATE('now');
2024-02-26
sqlite> select DATETIME('now');
2024-02-26 17:20:46
sqlite> select DATE('2024-02-26');
2024-02-26
sqlite> select DATETIME('2024-02-26');
2024-02-26 00:00:00
sqlite> select DATE('now', 'localtime');
2024-02-26
sqlite> select DATE('2024-02-26', 'localtime');
2024-02-25   <--- this is the bug