### PR TITLE
Fix sunrise/sunset scatter plots

### DIFF
--- a/scripts/plotly_streamlit.py
+++ b/scripts/plotly_streamlit.py
@@ -181,8 +181,8 @@ font_size = 15
 
 
 def sunrise_sunset_scatter(date_range):
-    latitude = df2['Lat'][-1]
-    longitude = df2['Lon'][-1]
+    latitude = df2['Lat'][0]
+    longitude = df2['Lon'][0]
 
     sun = Sun(latitude, longitude)
 

--- a/scripts/plotly_streamlit.py
+++ b/scripts/plotly_streamlit.py
@@ -12,7 +12,6 @@ from sqlite3 import Connection
 import plotly.express as px
 from sklearn.preprocessing import normalize
 from suntime import Sun
-from datetime import datetime
 
 profile = False
 if profile:

--- a/scripts/plotly_streamlit.py
+++ b/scripts/plotly_streamlit.py
@@ -181,9 +181,9 @@ top_N_species = (df5.value_counts()[:top_N])
 font_size = 15
 
 
-def sunrise_sunset_scatter(num_days_to_display):
-    latitude = df2['Lat'][0]
-    longitude = df2['Lon'][0]
+def sunrise_sunset_scatter(date_range):
+    latitude = df2['Lat'][-1]
+    longitude = df2['Lon'][-1]
 
     sun = Sun(latitude, longitude)
 
@@ -193,13 +193,13 @@ def sunrise_sunset_scatter(num_days_to_display):
     sunset_week_list = []
     sunrise_text_list = []
     sunset_text_list = []
+    daysback_range = []
 
     now = datetime.now()
 
-    for past_day in range(num_days_to_display):
-        d = timedelta(days=num_days_to_display - past_day - 1)
+    current_date = start_date
 
-        current_date = now - d
+    for current_date in date_range:
         # current_date = datetime.fromisocalendar(2022, week + 1, 5)
         # time_zone = datetime.now()
         sun_rise = sun.get_local_sunrise_time(current_date)
@@ -214,17 +214,17 @@ def sunrise_sunset_scatter(num_days_to_display):
         sunset_text_list.append(temp_time)
         sunrise_list.append(sun_rise_time)
         sunset_list.append(sun_dusk_time)
-        sunrise_week_list.append(past_day)
-        sunset_week_list.append(past_day)
+       
+        daysback_range.append(current_date.strftime('%d-%m-%Y'))
 
-    sunrise_week_list.append(None)
     sunrise_list.append(None)
     sunrise_text_list.append(None)
     sunrise_list.extend(sunset_list)
-    sunrise_week_list.extend(sunset_week_list)
     sunrise_text_list.extend(sunset_text_list)
+    daysback_range.append(None)
+    daysback_range.extend(daysback_range)
 
-    return sunrise_week_list, sunrise_list, sunrise_text_list
+    return daysback_range, sunrise_list, sunrise_text_list
 
 
 def hms_to_dec(t):
@@ -464,12 +464,7 @@ if daily is False:
             # text=labels,
             texttemplate="%{text}", autocolorscale=False, colorscale=selected_pal
         )
-        num_days_to_display = len(fig_x)
-        sunrise_week_list, sunrise_list, sunrise_text_list = sunrise_sunset_scatter(num_days_to_display)
-        daysback_range = fig_x
-        daysback_range.append(None)
-        daysback_range.extend(daysback_range)
-        daysback_range = daysback_range[:-1]
+        daysback_range, sunrise_list, sunrise_text_list = sunrise_sunset_scatter(day_hour_freq.index.tolist())
 
         sunrise_sunset = go.Scatter(x=daysback_range,
                                     y=sunrise_list,

--- a/scripts/plotly_streamlit.py
+++ b/scripts/plotly_streamlit.py
@@ -189,13 +189,9 @@ def sunrise_sunset_scatter(date_range):
 
     sunrise_list = []
     sunset_list = []
-    sunrise_week_list = []
-    sunset_week_list = []
     sunrise_text_list = []
     sunset_text_list = []
     daysback_range = []
-
-    now = datetime.now()
 
     current_date = start_date
 
@@ -214,7 +210,7 @@ def sunrise_sunset_scatter(date_range):
         sunset_text_list.append(temp_time)
         sunrise_list.append(sun_rise_time)
         sunset_list.append(sun_dusk_time)
-       
+
         daysback_range.append(current_date.strftime('%d-%m-%Y'))
 
     sunrise_list.append(None)


### PR DESCRIPTION
This bug has affected me for a while! I finally got to fixing it now that there's an active fork to benefit from the fix. :)

Sunrise/sunset scatter plots are misplaced for
* Date ranges that are a subset of the entire DB date range
* Species whose first/last detections are inside the bounds of the current date range.

This fixes those problems by using the same date range as the heatmap data. Before, it was making a simple date count from "now" without paying attention to the date bounds of the heatmap data.

To see these heatmaps and reproduce the problem: 
* launch "Species Stats"
* On the left, select "DAILY"
* (a) use the date range sliders to narrow the date range and pick a species on the right, or
* (b) leave the date range as is, and pick a species on the right that you have sparse detections for
* BUG: The sunrise/sunset lines will be wrong for the dates shown.

Additional notes: 

There are a lot of issues from this code that come from the original repo. The heat maps are beautiful if you've been running birdnet-pi for a while, but they are very slow!

I see a lot of room for improving the performance here, because it basically works with your entire DB starting with a "SELECT * FROM detections;" I have close to 700K detections on my system (mostly Canada Geese, I live by a river) and the Species Stats pane takes several seconds to work. Narrowing date ranges makes it incredibly slow. Plus, the way that the heatmap can be different than the date range selected isn't ideal, but I'm not fixing that here yet.

So this is a "simple" fix just to get the sunrise/set lines to align, as I get to understand how pandas and plotly work.

Below are some images of before/after this fix on my system:

Before: Eastern Phoebe (active just before dawn). Despite a full date range selected, the heatmap stops in October (when they left last fall) but the sunrise/sunset dates are for the full period.
![Screenshot 2024-03-07 8 52 35 PM](https://github.com/Nachtzuster/BirdNET-Pi/assets/16225729/64386a7b-1d4c-459e-9897-75027f150745)

After: the sunrise/sunset dates respect the inputted date range.
![Screenshot 2024-03-07 9 01 21 PM](https://github.com/Nachtzuster/BirdNET-Pi/assets/16225729/6ddc12ba-fe6e-4781-ab5d-84f71ef63f34)

Before: Canada Geese, for a narrowed date range. The geese are most active around sunrise/sunset, but the sunrise/sunset lines don't match the dates (note how despite it being summer, sunrise is getting "later" -  red arrow)
![Screenshot 2024-03-07 8 55 43 PM](https://github.com/Nachtzuster/BirdNET-Pi/assets/16225729/c50424a7-6ed0-4703-a0ba-d279e4807695)

After: Canada Geese activity aligns with sunrise/sunset, and the summer solstice has the earliest sunrise again (green arrow)
![Screenshot 2024-03-07 8 59 39 PM](https://github.com/Nachtzuster/BirdNET-Pi/assets/16225729/d80b54d1-58c7-440e-b6f6-b4e0e7a73c7b)

Let me know if you have any questions or concerns. :)