### PR TITLE
Change repo in System Controls

### DIFF
--- a/scripts/system_controls.php
+++ b/scripts/system_controls.php
@@ -49,7 +49,7 @@ function update() {
   $curr_hash = shell_exec($cmd);
 ?>
   <p style="font-size:11px;text-align:center"></br></br>Running version: </p>
-  <a href="https://github.com/mcguirepr89/BirdNET-Pi/commit/<?php echo $curr_hash; ?>" target="_blank">
+  <a href="https://github.com/Nachtzuster/BirdNET-Pi/commit/<?php echo $curr_hash; ?>" target="_blank">
     <p style="font-size:11px;text-align:center;box-sizing: border-box"><?php echo $curr_hash; ?></p>
   </a>
 </div>


### PR DESCRIPTION
Pointer is to the original repo when checking for latest commits to display hash. Change to Nachtzuster repo to reflect proper hash.