### PR TITLE
Read lat/lon from config

### DIFF
--- a/scripts/plotly_streamlit.py
+++ b/scripts/plotly_streamlit.py
@@ -12,6 +12,7 @@ from sqlite3 import Connection
 import plotly.express as px
 from sklearn.preprocessing import normalize
 from suntime import Sun
+from utils.helpers import get_settings
 
 profile = False
 if profile:
@@ -181,8 +182,9 @@ font_size = 15
 
 
 def sunrise_sunset_scatter(date_range):
-    latitude = df2['Lat'][0]
-    longitude = df2['Lon'][0]
+    conf = get_settings()
+    latitude = conf.getfloat('LATITUDE')
+    longitude = conf.getfloat('LONGITUDE')
 
     sun = Sun(latitude, longitude)
 


### PR DESCRIPTION
Introduces usage of get_settings for determining latitude and longitude for sunrise and sunset scatter plots, as suggested in #16 .

With changes implemented, I deliberately broke my lat/lon config. Sunrise/sunset times change (e.g. are broken too) :

![Screenshot 2024-03-13 192659](https://github.com/Nachtzuster/BirdNET-Pi/assets/16225729/8eef30fe-e838-43c7-a1fb-a584e11f8750)

Fixing lat/lon again, the sunrise/sunset times are displayed as expected:

![Screenshot 2024-03-13 192930](https://github.com/Nachtzuster/BirdNET-Pi/assets/16225729/933dee3c-b1a7-4b3c-b378-d01df672c3bb)
