### PR TITLE
Fix : set_ticklabels warning

### DIFF
--- a/scripts/daily_plot.py
+++ b/scripts/daily_plot.py
@@ -98,7 +98,9 @@ def create_plot(df_plt_today, now, is_top=None):
 
     # Try plot grid lines between bars - problem at the moment plots grid lines on bars - want between bars
     yticklabels = ['\n'.join(textwrap.wrap(ticklabel.get_text(), 16)) for ticklabel in plot.get_yticklabels()]
-    plot.set_yticklabels(yticklabels, fontsize=10)
+    yticks = plot.get_yticks()  # Get the current y-ticks
+    plot.set_yticks(yticks)  # Set the y-ticks
+    plot.set_yticklabels(yticklabels, fontsize=10)  # Now set the y-tick labels
     plot.set(ylabel=None)
     plot.set(xlabel="Detections")
 

--- a/scripts/daily_plot.py
+++ b/scripts/daily_plot.py
@@ -98,8 +98,8 @@ def create_plot(df_plt_today, now, is_top=None):
 
     # Try plot grid lines between bars - problem at the moment plots grid lines on bars - want between bars
     yticklabels = ['\n'.join(textwrap.wrap(ticklabel.get_text(), 16)) for ticklabel in plot.get_yticklabels()]
-    yticks = plot.get_yticks()
     # Next two lines avoid a UserWarning on set_ticklabels() requesting a fixed number of ticks
+    yticks = plot.get_yticks()
     plot.set_yticks(yticks)
     plot.set_yticklabels(yticklabels, fontsize=10)
     plot.set(ylabel=None)

--- a/scripts/daily_plot.py
+++ b/scripts/daily_plot.py
@@ -99,6 +99,7 @@ def create_plot(df_plt_today, now, is_top=None):
     # Try plot grid lines between bars - problem at the moment plots grid lines on bars - want between bars
     yticklabels = ['\n'.join(textwrap.wrap(ticklabel.get_text(), 16)) for ticklabel in plot.get_yticklabels()]
     yticks = plot.get_yticks()
+    # Next two lines avoid a UserWarning on set_ticklabels() requesting a fixed number of ticks
     plot.set_yticks(yticks)
     plot.set_yticklabels(yticklabels, fontsize=10)
     plot.set(ylabel=None)

--- a/scripts/daily_plot.py
+++ b/scripts/daily_plot.py
@@ -98,9 +98,9 @@ def create_plot(df_plt_today, now, is_top=None):
 
     # Try plot grid lines between bars - problem at the moment plots grid lines on bars - want between bars
     yticklabels = ['\n'.join(textwrap.wrap(ticklabel.get_text(), 16)) for ticklabel in plot.get_yticklabels()]
-    yticks = plot.get_yticks()  # Get the current y-ticks
-    plot.set_yticks(yticks)  # Set the y-ticks
-    plot.set_yticklabels(yticklabels, fontsize=10)  # Now set the y-tick labels
+    yticks = plot.get_yticks()
+    plot.set_yticks(yticks)
+    plot.set_yticklabels(yticklabels, fontsize=10)
     plot.set(ylabel=None)
     plot.set(xlabel="Detections")
 


### PR DESCRIPTION
When the `chart_viewer.service` starts, there is a warning : `UserWarning: set_ticklabels() should only be used with a fixed number of ticks, i.e. after set_ticks() or using a FixedLocator."`

This should fix it, at least tested on my system (rpi4 aarch64) but should be transversal to all systems