### PR TITLE
FEAT proposal : convert species on the fly

### DIFF
--- a/scripts/clear_all_data.sh
+++ b/scripts/clear_all_data.sh
@@ -24,6 +24,7 @@ echo "Re-creating necessary directories"
 
 sudo -u ${USER} ln -fs $(dirname $my_dir)/exclude_species_list.txt $my_dir
 sudo -u ${USER} ln -fs $(dirname $my_dir)/include_species_list.txt $my_dir
+sudo -u ${USER} ln -fs $(dirname $my_dir)/convert_species_list.txt $my_dir
 sudo -u ${USER} ln -fs $(dirname $my_dir)/homepage/* ${EXTRACTED}
 sudo -u ${USER} ln -fs $(dirname $my_dir)/model/labels.txt ${my_dir}
 sudo -u ${USER} ln -fs $my_dir ${EXTRACTED}

--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -66,6 +66,7 @@ create_necessary_dirs() {
   [ -L ${EXTRACTED}/spectrogram.png ] || sudo -u ${USER} ln -sf ${RECS_DIR}/StreamData/spectrogram.png ${EXTRACTED}/spectrogram.png
 
   sudo -u ${USER} ln -fs $my_dir/exclude_species_list.txt $my_dir/scripts
+  sudo -u ${USER} ln -fs $my_dir/convert_species_list.txt $my_dir/scripts
   sudo -u ${USER} ln -fs $my_dir/include_species_list.txt $my_dir/scripts
   sudo -u ${USER} ln -fs $my_dir/homepage/* ${EXTRACTED}
   sudo -u ${USER} ln -fs $my_dir/model/labels.txt ${my_dir}/scripts

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 
 userDir = os.path.expanduser('~')
-INTERPRETER, M_INTERPRETER, INCLUDE_LIST, EXCLUDE_LIST = (None, None, None, None)
+INTERPRETER, M_INTERPRETER, INCLUDE_LIST, EXCLUDE_LIST, CONVERT_LIST = (None, None, None, None, None)
 PREDICTED_SPECIES_LIST = []
 model, priv_thresh, sf_thresh = (None, None, None)
 
@@ -307,7 +307,7 @@ def load_global_model():
 
 
 def run_analysis(file):
-    global INCLUDE_LIST, EXCLUDE_LIST
+    global INCLUDE_LIST, EXCLUDE_LIST, CONVERT_LIST
     INCLUDE_LIST = loadCustomSpeciesList(os.path.expanduser("~/BirdNET-Pi/include_species_list.txt"))
     EXCLUDE_LIST = loadCustomSpeciesList(os.path.expanduser("~/BirdNET-Pi/exclude_species_list.txt"))
     CONVERT_LIST = loadCustomSpeciesList(os.path.expanduser("~/BirdNET-Pi/convert_species_list.txt"))

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -329,11 +329,12 @@ def run_analysis(file):
         log.info('%s-%s', time_slot, entries[0])
         for entry in entries:
             # Check if the user has requested to replace a specie by another for bias correction
-            for convert_entry in CONVERT_LIST:
-                parts = convert_entry.split(';')
-                if entry[1] == parts[0]:
-                    entry[1] = parts[1]
-                    break
+            if len(EXCLUDE_LIST) != 0:
+                for convert_entry in CONVERT_LIST:
+                    parts = convert_entry.split(';')
+                    if entry[1] == parts[0]:
+                        entry[1] = parts[1]
+                        break
             if entry[1] >= conf.getfloat('CONFIDENCE') and ((entry[0] in INCLUDE_LIST or len(INCLUDE_LIST) == 0)
                                                             and (entry[0] not in EXCLUDE_LIST or len(EXCLUDE_LIST) == 0)
                                                             and (entry[0] in PREDICTED_SPECIES_LIST

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -310,6 +310,7 @@ def run_analysis(file):
     global INCLUDE_LIST, EXCLUDE_LIST
     INCLUDE_LIST = loadCustomSpeciesList(os.path.expanduser("~/BirdNET-Pi/include_species_list.txt"))
     EXCLUDE_LIST = loadCustomSpeciesList(os.path.expanduser("~/BirdNET-Pi/exclude_species_list.txt"))
+    CONVERT_LIST = loadCustomSpeciesList(os.path.expanduser("~/BirdNET-Pi/convert_species_list.txt"))
 
     conf = get_settings()
 

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -328,6 +328,12 @@ def run_analysis(file):
     for time_slot, entries in raw_detections.items():
         log.info('%s-%s', time_slot, entries[0])
         for entry in entries:
+            # Check if the user has requested to replace a specie by another for bias correction
+            for convert_entry in CONVERT_LIST:
+                parts = convert_entry.split(';')
+                if entry[1] == parts[0]:
+                    entry[1] = parts[1]
+                    break
             if entry[1] >= conf.getfloat('CONFIDENCE') and ((entry[0] in INCLUDE_LIST or len(INCLUDE_LIST) == 0)
                                                             and (entry[0] not in EXCLUDE_LIST or len(EXCLUDE_LIST) == 0)
                                                             and (entry[0] in PREDICTED_SPECIES_LIST


### PR DESCRIPTION
ISSUE : At least two common birds in my garden are systematically misidentified as another very rare specie, when they perform a call instead of a song. I don't want to exclude those birds however of they would never be recognized as it is a systematic model issue

PROPOSED SOLUTION : This PR proposes the use of an optional user created "convert_species_list.txt" in the format "old sci name_old common name;new sci name_new common name" to avoid this

COMMENT : I've modified code using the management of the exclude_species_list.txt as template to create and init the file. The only specific code written is its usage in the server.py