### PR TITLE
Feat : Add site_info to the title of the species accessed through Recordings or Unique species

### DIFF
--- a/scripts/common.php
+++ b/scripts/common.php
@@ -109,7 +109,7 @@ function get_sci_name($com_name) {
   }
   $sciname = null;
   foreach ($_labels_flickr as $label) {
-    if (strpos($label, $sci_name) !== false) {
+    if (strpos($label, $com_name) !== false) {
       $sciname = trim(explode("_", $label)[0]);
       break;
     }

--- a/scripts/common.php
+++ b/scripts/common.php
@@ -104,11 +104,11 @@ function get_com_en_name($sci_name) {
 }
 
 function get_sci_name($com_name) {
-  if (!isset($_labels_flickr)) {
-    $_labels_flickr = file(get_home() . "/BirdNET-Pi/model/labels.txt");
+  if (!isset($_labels)) {
+    $_labels = file(get_home() . "/BirdNET-Pi/model/labels.txt");
   }
   $sciname = null;
-  foreach ($_labels_flickr as $label) {
+  foreach ($_labels as $label) {
     if (strpos($label, $com_name) !== false) {
       $sciname = trim(explode("_", $label)[0]);
       break;

--- a/scripts/common.php
+++ b/scripts/common.php
@@ -103,6 +103,20 @@ function get_com_en_name($sci_name) {
   return $engname;
 }
 
+function get_sci_name($com_name) {
+  if (!isset($_labels_flickr)) {
+    $_labels_flickr = file(get_home() . "/BirdNET-Pi/model/labels_flickr.txt");
+  }
+  $sciname = null;
+  foreach ($_labels_flickr as $label) {
+    if (strpos($label, $sci_name) !== false) {
+      $sciname = trim(explode("_", $label)[0]);
+      break;
+    }
+  }
+  return $sciname;
+}
+
 define('DB', './scripts/flickr.db');
 
 class Flickr {

--- a/scripts/common.php
+++ b/scripts/common.php
@@ -105,7 +105,7 @@ function get_com_en_name($sci_name) {
 
 function get_sci_name($com_name) {
   if (!isset($_labels_flickr)) {
-    $_labels_flickr = file(get_home() . "/BirdNET-Pi/model/labels_flickr.txt");
+    $_labels_flickr = file(get_home() . "/BirdNET-Pi/model/labels.txt");
   }
   $sciname = null;
   foreach ($_labels_flickr as $label) {

--- a/scripts/play.php
+++ b/scripts/play.php
@@ -644,12 +644,9 @@ echo "<table>
     $statement2 = $db->prepare("SELECT * FROM detections where File_name == \"$name\" ORDER BY Date DESC, Time DESC");
     ensure_db_ok($statement2);
     $result2 = $statement2->execute();
-    $sciname = get_sci_name($name);
-    $info_url = get_info_url($sciname);
-    $url = $info_url['URL'];
     echo "<table>
       <tr>
-      <th><a href=\"$url\" target=\"top\">$name</a></th>
+      <th>$name</th>
       </tr>";
       while($results=$result2->fetchArray(SQLITE3_ASSOC))
       {

--- a/scripts/play.php
+++ b/scripts/play.php
@@ -536,6 +536,7 @@ if ($fp) {
   $disk_check_exclude_arr = [];
 }
 
+$sciname = 
 $name = htmlspecialchars_decode($_GET['species'], ENT_QUOTES);
 if(isset($_SESSION['date'])) {
   $date = $_SESSION['date'];
@@ -558,10 +559,6 @@ while ($result2->fetchArray(SQLITE3_ASSOC)) {
     $num_rows++;
 }
 $result2->reset(); // reset the pointer to the beginning of the result set
-echo "<table>
-  <tr>
-  <th>$name</th>
-  </tr>";
   $iter=0;
   while($results=$result2->fetchArray(SQLITE3_ASSOC))
   {
@@ -613,7 +610,11 @@ echo "<table>
         $shiftTitle = "This file is not shifted in frequency.";
         $shiftAction = "shift";
       }
-
+  $info_url = get_info_url($sciname);
+      echo "<table>
+  <tr>
+  <th><a href=\"$info_url\">$name</a></th>
+  </tr>";
       echo "<tr>
   <td class=\"relative\"> 
 

--- a/scripts/play.php
+++ b/scripts/play.php
@@ -644,9 +644,13 @@ echo "<table>
     $statement2 = $db->prepare("SELECT * FROM detections where File_name == \"$name\" ORDER BY Date DESC, Time DESC");
     ensure_db_ok($statement2);
     $result2 = $statement2->execute();
+    $comname = str_replace("_", " ", strtok($name, '-'));
+    $sciname = get_sci_name($comname);
+    $info_url = get_info_url($sciname);
+    $url = $info_url['URL'];
     echo "<table>
       <tr>
-      <th>$name</th>
+      <th><a href=\"$url\" target=\"top\">$comname ($name)</a></th>
       </tr>";
       while($results=$result2->fetchArray(SQLITE3_ASSOC))
       {

--- a/scripts/play.php
+++ b/scripts/play.php
@@ -536,7 +536,6 @@ if ($fp) {
   $disk_check_exclude_arr = [];
 }
 
-$sciname = 
 $name = htmlspecialchars_decode($_GET['species'], ENT_QUOTES);
 if(isset($_SESSION['date'])) {
   $date = $_SESSION['date'];
@@ -610,14 +609,10 @@ $result2->reset(); // reset the pointer to the beginning of the result set
         $shiftTitle = "This file is not shifted in frequency.";
         $shiftAction = "shift";
       }
-  $info_url = get_info_url($sciname);
-      echo "<table>
-  <tr>
-  <th><a href=\"$info_url\">$name</a></th>
-  </tr>";
-      echo "<tr>
-  <td class=\"relative\"> 
-
+  $info_url = get_info_url($results['Sci_Name']);
+  $url = $info_url['URL'];
+  echo "<table><tr><th><a href=\"$url\" target=\"top\">$name</a></th>
+</tr><td class=\"relative\">
 <img style='cursor:pointer;right:120px' src='images/delete.svg' onclick='deleteDetection(\"".$filename_formatted."\")' class=\"copyimage\" width=25 title='Delete Detection'> 
 <img style='cursor:pointer;right:85px' src='images/bird.svg' onclick='changeDetection(\"".$filename_formatted."\")' class=\"copyimage\" width=25 title='Change Detection'> 
 <img style='cursor:pointer;right:45px' onclick='toggleLock(\"".$filename_formatted."\",\"".$type."\", this)' class=\"copyimage\" width=25 title=\"".$title."\" src=\"".$imageicon."\"> 

--- a/scripts/play.php
+++ b/scripts/play.php
@@ -650,7 +650,7 @@ echo "<table>
     $url = $info_url['URL'];
     echo "<table>
       <tr>
-      <th><a href=\"$url\" target=\"top\">$comname ($name)</a></th>
+      <th><a href=\"$url\" target=\"top\">$name</a></th>
       </tr>";
       while($results=$result2->fetchArray(SQLITE3_ASSOC))
       {

--- a/scripts/play.php
+++ b/scripts/play.php
@@ -558,6 +558,13 @@ while ($result2->fetchArray(SQLITE3_ASSOC)) {
     $num_rows++;
 }
 $result2->reset(); // reset the pointer to the beginning of the result set
+$sciname = get_sci_name($name);
+$info_url = get_info_url($sciname);
+$url = $info_url['URL'];
+echo "<table>
+  <tr>
+  <th><a href=\"$url\" target=\"top\">$name</a></th>
+  </tr>";
   $iter=0;
   while($results=$result2->fetchArray(SQLITE3_ASSOC))
   {
@@ -609,10 +616,10 @@ $result2->reset(); // reset the pointer to the beginning of the result set
         $shiftTitle = "This file is not shifted in frequency.";
         $shiftAction = "shift";
       }
-  $info_url = get_info_url($results['Sci_Name']);
-  $url = $info_url['URL'];
-  echo "<table><tr><th><a href=\"$url\" target=\"top\">$name</a></th>
-</tr><td class=\"relative\">
+
+      echo "<tr>
+  <td class=\"relative\"> 
+
 <img style='cursor:pointer;right:120px' src='images/delete.svg' onclick='deleteDetection(\"".$filename_formatted."\")' class=\"copyimage\" width=25 title='Delete Detection'> 
 <img style='cursor:pointer;right:85px' src='images/bird.svg' onclick='changeDetection(\"".$filename_formatted."\")' class=\"copyimage\" width=25 title='Change Detection'> 
 <img style='cursor:pointer;right:45px' onclick='toggleLock(\"".$filename_formatted."\",\"".$type."\", this)' class=\"copyimage\" width=25 title=\"".$title."\" src=\"".$imageicon."\"> 
@@ -637,9 +644,12 @@ $result2->reset(); // reset the pointer to the beginning of the result set
     $statement2 = $db->prepare("SELECT * FROM detections where File_name == \"$name\" ORDER BY Date DESC, Time DESC");
     ensure_db_ok($statement2);
     $result2 = $statement2->execute();
+    $sciname = get_sci_name($name);
+    $info_url = get_info_url($sciname);
+    $url = $info_url['URL'];
     echo "<table>
       <tr>
-      <th>$name</th>
+      <th><a href=\"$url\" target=\"top\">$name</a></th>
       </tr>";
       while($results=$result2->fetchArray(SQLITE3_ASSOC))
       {


### PR DESCRIPTION
Currently, the play.php page accessed through Recordings or Today species only shows as a text the common name of the specie

This PR takes advantage of the new site_info function to add a ebird/allaboutbirds link to the title, allowing a faster access and a bit more harmonized management with other pages