### PR TITLE
Fix: Ignore warnings from `lsof` output

### DIFF
--- a/scripts/utils/helpers.py
+++ b/scripts/utils/helpers.py
@@ -88,7 +88,7 @@ class ParseFileName:
 
 
 def get_open_files_in_dir(dir_name):
-    result = subprocess.run(['lsof', '-Fn', '+D', f'{dir_name}'], check=False, capture_output=True)
+    result = subprocess.run(['lsof', '-w', '-Fn', '+D', f'{dir_name}'], check=False, capture_output=True)
     ret = result.stdout.decode('utf-8')
     err = result.stderr.decode('utf-8')
     if err:


### PR DESCRIPTION
## Overview

I run a few Docker containers on the same system that runs BirdNET-Pi and I've noticed this can cause issues with the `lsof` command that looks for `.wav` files to process. Here is what I would see when Docker is running:

```
12:12:59--- lsof: WARNING: can't stat() overlay file system /var/lib/docker/overlay2/7ee00bfe5a0d2d841a053baaf7fb23b47f09c056c2806568ec9e53762bf4cdea/merged
12:12:59---      Output information may be incomplete.
12:12:59---lsof: WARNING: can't stat() overlay file system /var/lib/docker/overlay2/739026a51809ca99ba0244fd1999abb2fe074659d984b4ec6b4dfaf560dc8c23/merged
12:12:59---      Output information may be incomplete.
12:12:59---lsof: WARNING: can't stat() nsfs file system /run/docker/netns/8a59faa891ac
12:12:59---      Output information may be incomplete.
12:12:59---lsof: WARNING: can't stat() nsfs file system /run/docker/netns/82b83ba51d51
12:12:59---      Output information may be incomplete.
12:13:02---[server][INFO] LOADING TF LITE MODEL...
12:13:02---INFO: Created TensorFlow Lite XNNPACK delegate for CPU.
12:13:02---[server][INFO] LOADING DONE!
12:13:02---Traceback (most recent call last):
12:13:02---  File "/usr/local/bin/birdnet_analysis.py", line 149, in <module>
12:13:02---    main()
12:13:02---  File "/usr/local/bin/birdnet_analysis.py", line 36, in main
12:13:02---    backlog = get_wav_files()
12:13:02---              ^^^^^^^^^^^^^^^
12:13:02---  File "BirdNET-Pi/scripts/utils/helpers.py", line 107, in get_wav_files
12:13:02---    open_recs = get_open_files_in_dir(rec_dir)
12:13:02---                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
12:13:02---  File "BirdNET-Pi/scripts/utils/helpers.py", line 95, in get_open_files_in_dir
12:13:02---    raise RuntimeError(f'{ret}:\n {err}')
12:13:02---RuntimeError: p1317
12:13:02---nBirdSongs/StreamData/2024-08-17-birdnet-12:12:58.wav
```

## Proposed fix

The included fix adds `-w` to the list of arguments provided to `lsof` to ignore warnings. According to the `lsof` man page, `-w`:

```
       +|-w     Enables (+) or disables (-) the suppression of warning messages.

                The  lsof  builder  may choose to have warning messages disabled or enabled by default.  The default warning message state is indicated in
                the output of the -h or -?  option.  Disabling warning messages when they are already disabled or enabling them when  already  enabled  is
                acceptable.

                The -t option implies the -w option.
```
