### PR TITLE
Ignore all local databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ Birders_Guide_Installer_Configuration.txt
 birdnet/
 templates/*.service
 scripts/*.txt
-scripts/birds.db
+scripts/*.db
 analyzing_now.txt
 apprise.txt
 BirdDB.txt


### PR DESCRIPTION
All local databases should be ignored by git. They are specific to each installation and do not belong in the repository. 