### PR TITLE
disable apache2 before enabling caddy

### DIFF
--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -211,7 +211,9 @@ http:// ${BIRDNETPI_URL} {
 EOF
   fi
 
-  systemctl disable apache2
+  if systemctl is-enabled --quiet apache2 &>/dev/null; then
+    systemctl disable apache2
+  fi
   systemctl enable caddy
   usermod -aG $USER caddy
   usermod -aG video caddy

--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -211,6 +211,7 @@ http:// ${BIRDNETPI_URL} {
 EOF
   fi
 
+  systemctl disable apache2
   systemctl enable caddy
   usermod -aG $USER caddy
   usermod -aG video caddy


### PR DESCRIPTION
apache2 is automatically starting as a dependency and needs to be disabled before starting caddy