### PR TITLE
$_SERVER['PHP_AUTH_PW'] isn't always sent

### DIFF
--- a/scripts/common.php
+++ b/scripts/common.php
@@ -66,7 +66,7 @@ function get_service_mount_name() {
 
 function is_authenticated() {
   $ret = false;
-  if (isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {
+  if (isset($_SERVER['PHP_AUTH_USER'])) {
     $config = get_config();
     $ret = ($_SERVER['PHP_AUTH_PW'] == $config['CADDY_PWD'] && $_SERVER['PHP_AUTH_USER'] == 'birdnet');
   }


### PR DESCRIPTION
This PR aims to fix https://github.com/Nachtzuster/BirdNET-Pi/issues/243.

I previously never provided a password which worked OK,  but `isset($_SERVER['PHP_AUTH_PW'])` now returns `false`, which means `if (isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {` returns `false` and so returns an overall result of `false` (which fails auth).

The change below removes the `if (isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {` check entirely as it seems to work correctly without it.

I honestly don't know why this is now necessary as I can't see any recent code changes, perhaps a recent PHP upgrade caused this?