### PR TITLE
Restore unique RTSP identifier to extracted file names

### DIFF
--- a/scripts/utils/reporting.py
+++ b/scripts/utils/reporting.py
@@ -63,7 +63,7 @@ def spectrogram(in_file, title, comment, raw=False):
 
 def extract_detection(file: ParseFileName, detection: Detection):
     conf = get_settings()
-    new_file_name = f'{detection.common_name_safe}-{detection.confidence_pct}-{detection.date}-birdnet-{detection.time}.{conf["AUDIOFMT"]}'
+    new_file_name = f'{detection.common_name_safe}-{detection.confidence_pct}-{detection.date}-birdnet-{file.RTSP_id}{detection.time}.{conf["AUDIOFMT"]}'
     new_dir = os.path.join(conf['EXTRACTED'], 'By_Date', f'{detection.date}', f'{detection.common_name_safe}')
     new_file = os.path.join(new_dir, new_file_name)
     if os.path.isfile(new_file):


### PR DESCRIPTION
Add back an identifier of the RTSP stream an extracted file was derived from to the file name of an extracted birdsong.  The identifier thereby becomes included in the filename listed in birds.db, and hence is accessible for any post-processing utilities that may require the location of the microphone that picked up a particular birdsong.  Knowing the detection location of a birdsong has the potential to be very useful, for example for later examining camera footage to see if images of the identified bird are available.  

This PR augments the Nov 20 2024 commit 'Use detection time instead of origin audio file time in DB' by restoring the RTSP stream ID into the extracted birdsong file name.