### PR TITLE
Add Purge Threshold

### DIFF
--- a/scripts/advanced.php
+++ b/scripts/advanced.php
@@ -130,6 +130,13 @@ if(isset($_GET['submit'])) {
     }
   }
 
+  if (isset($_GET["purge_threshold"])) {
+    $purge_threshold = $_GET["purge_threshold"];
+    if (strcmp($purge_threshold, $config['PURGE_THERSHOLD']) !== 0) {
+        $contents = preg_replace("/PURGE_THERSHOLD=.*/", "PURGE_THERSHOLD=$purge_threshold", $contents);
+    }
+}
+
 if (isset($_GET["max_files_species"])) {
     $max_files_species = $_GET["max_files_species"];
     if (strcmp($max_files_species, $config['MAX_FILES_SPECIES']) !== 0) {
@@ -288,6 +295,11 @@ $newconfig = get_config();
       <input name="full_disk" type="radio" id="keep" value="keep" <?php if (strcmp($newconfig['FULL_DISK'], "keep") == 0) { echo "checked"; }?>>Keep</label>
       <p>When the disk becomes full, you can choose to 'purge' old files to make room for new ones or 'keep' your data and stop all services instead.<br>Note: you can exclude specific files from 'purge' on the Recordings page.</p>
       <br>
+      <label for="purge_threshold">Purge Threshold (Disk Used %):</label>
+      <input name="purge_threshold" type="number" style="width:6em;" min="20" max="99" step="1" value="<?php print($newconfig['PURGE_THRESHOLD']);?>"/>
+      </td></tr><tr><td>
+      <p>Defines how full the disk should be before the purge operations occur.<br>Note: This variable is still active if Keep is set. This means that the servies will be stopped at the purge threshold.</p>
+      </td></tr><tr><td>
       <label for="max_files_species">Amount of files to keep for each species :</label>
       <input name="max_files_species" type="number" style="width:6em;" min="0" step="1" value="<?php print($newconfig['MAX_FILES_SPECIES']);?>"/>
       </td></tr><tr><td>

--- a/scripts/advanced.php
+++ b/scripts/advanced.php
@@ -132,8 +132,8 @@ if(isset($_GET['submit'])) {
 
   if (isset($_GET["purge_threshold"])) {
     $purge_threshold = $_GET["purge_threshold"];
-    if (strcmp($purge_threshold, $config['PURGE_THERSHOLD']) !== 0) {
-        $contents = preg_replace("/PURGE_THERSHOLD=.*/", "PURGE_THERSHOLD=$purge_threshold", $contents);
+    if (strcmp($purge_threshold, $config['PURGE_THRESHOLD']) !== 0) {
+        $contents = preg_replace("/PURGE_THRESHOLD=.*/", "PURGE_THRESHOLD=$purge_threshold", $contents);
     }
 }
 
@@ -297,9 +297,7 @@ $newconfig = get_config();
       <br>
       <label for="purge_threshold">Purge Threshold (Disk Used %):</label>
       <input name="purge_threshold" type="number" style="width:6em;" min="20" max="99" step="1" value="<?php print($newconfig['PURGE_THRESHOLD']);?>"/>
-      </td></tr><tr><td>
-      <p>Defines how full the disk should be before the purge operations occur.<br>Note: This variable is still active if Keep is set. This means that the servies will be stopped at the purge threshold.</p>
-      </td></tr><tr><td>
+      <p>Defines how full the disk should be before the purge operations occur.<br>Note: This variable is still active if Keep is set. This means that the servies will be stopped at the purge threshold.</p><br>
       <label for="max_files_species">Amount of files to keep for each species :</label>
       <input name="max_files_species" type="number" style="width:6em;" min="0" step="1" value="<?php print($newconfig['MAX_FILES_SPECIES']);?>"/>
       </td></tr><tr><td>

--- a/scripts/disk_check.sh
+++ b/scripts/disk_check.sh
@@ -3,8 +3,9 @@ set -x
 
 source /etc/birdnet/birdnet.conf
 used="$(df -h ${EXTRACTED} | tail -n1 | awk '{print $5}')"
+purge_threshold="${PURGE_THRESHOLD:-95}"
 
-if [ "${used//%}" -ge 95 ]; then
+if [ "${used//%}" -ge "$purge_threshold" ]; then
 
   case $FULL_DISK in
     purge) echo "Removing oldest data"
@@ -34,7 +35,7 @@ if [ "${used//%}" -ge 95 ]; then
   esac
 fi
 sleep 1
-if [ "${used//%}" -ge 95 ]; then
+if [ "${used//%}" -ge "$purge_threshold" ]; then
   case $FULL_DISK in
     purge) echo "Removing more data"
        rm -rfv ${PROCESSED}/*;;

--- a/scripts/install_config.sh
+++ b/scripts/install_config.sh
@@ -136,6 +136,10 @@ COLOR_SCHEME="light"
 
 FULL_DISK=purge
 
+## PURGE_THRESHOLD can be set to configure at what disk full percentage the
+## purge operations are triggered.
+PURGE_THRESHOLD=95
+
 ## Maximum amount of files to keep for a given specie (0 = keep all)
 ## Files from the last 7 days, and files protected from purge, are not taken into
 ## account in this number

--- a/scripts/update_birdnet_snippets.sh
+++ b/scripts/update_birdnet_snippets.sh
@@ -95,7 +95,7 @@ if ! grep -E '^COLOR_SCHEME=' /etc/birdnet/birdnet.conf &>/dev/null;then
 fi
 
 if ! grep -E '^PURGE_THRESHOLD=' /etc/birdnet/birdnet.conf &>/dev/null;then
-  echo "PURGE_THRESHOLD=\"95\"" >> /etc/birdnet/birdnet.conf
+  echo "PURGE_THRESHOLD=95" >> /etc/birdnet/birdnet.conf
 fi
 
 if ! grep -E '^MAX_FILES_SPECIES=' /etc/birdnet/birdnet.conf &>/dev/null;then

--- a/scripts/update_birdnet_snippets.sh
+++ b/scripts/update_birdnet_snippets.sh
@@ -94,6 +94,10 @@ if ! grep -E '^COLOR_SCHEME=' /etc/birdnet/birdnet.conf &>/dev/null;then
   echo "COLOR_SCHEME=\"light\"" >> /etc/birdnet/birdnet.conf
 fi
 
+if ! grep -E '^PURGE_THRESHOLD=' /etc/birdnet/birdnet.conf &>/dev/null;then
+  echo "PURGE_THRESHOLD=\"95\"" >> /etc/birdnet/birdnet.conf
+fi
+
 if ! grep -E '^MAX_FILES_SPECIES=' /etc/birdnet/birdnet.conf &>/dev/null;then
   echo "MAX_FILES_SPECIES=\"0\"" >> /etc/birdnet/birdnet.conf
 fi


### PR DESCRIPTION
**Problem**

Currently, the threshold at which files are purged from disk is hard coded at 95%. Depending on users and systems this can be either too high or too low. Editing the threshold to adjust for user preferences would have to be done in the script where the disk cleanup is run. This is less than ideal because it puts this control out of scope for less technical users and would be wiped out or cause issues during updates.

**Proposed Change**

Add a purge threshold setting. This setting allows the user to control at what filled percentage the purge activities are run.

**Detailed Description of Changes**

1. Adds a configuration item to `advanced.php` to set the purge threshold. Also adds relevant description and warnings.

    - The current setting allow a range of 20-99 percent. These felt sensible to me but I'm open to changing them.
    -  **Note:** The purge threshold is still active when the user has set Keep mode. This does present a risk that a user will set a low threshold while in keep mode and the services will be shut down sooner than they expect. This may warrant a more advanced implementation if it is felt that this is a sufficiently large risk.

2. Adds a snippet to `update_birdnet_snippets.sh` to set the default purge threshold. The default matches the threshold that was previously hardcoded. 
3. Changes the space equivalence check in `disk_check.sh` to use the newly defined purge threshold.
4. Adds the purge threshold to `install_config.sh`
