### PR TITLE
UI : recordings limit

### DIFF
--- a/scripts/play.php
+++ b/scripts/play.php
@@ -570,6 +570,7 @@ if ($fp) {
 }
 
 $name = htmlspecialchars_decode($_GET['species'], ENT_QUOTES);
+$limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 40;
 if(isset($_SESSION['date'])) {
   $date = $_SESSION['date'];
   if(isset($_GET['sort']) && $_GET['sort'] == "confidence") {
@@ -623,6 +624,10 @@ echo "<table>
       continue;
     }
     $iter++;
+    if($iter > $limit) {
+      $iter_additional=true;
+      break;
+    }
 
     if($num_rows < 100){
       $imageelem = "<video onplay='setLiveStreamVolume(0)' onended='setLiveStreamVolume(1)' onpause='setLiveStreamVolume(1)' controls poster=\"$filename_png\" preload=\"none\" title=\"$filename\"><source src=\"$filename\"></video>";
@@ -664,6 +669,26 @@ echo "<table>
         </tr>";
 
   }if($iter == 0){ echo "<tr><td><b>No recordings were found.</b><br><br><span style='font-size:medium'>They may have been deleted to make space for new recordings. You can prevent this from happening in the future by clicking the <img src='images/unlock.svg' style='width:20px'> icon in the top right of a recording.<br>You can also modify this behavior globally under \"Full Disk Behavior\" <a href='views.php?view=Advanced'>here.</a></span></td></tr>";}echo "</table>";}
+
+  if ($iter_additional) {
+    echo "<div style='text-align:center'>";
+    echo "<form action='views.php' method='GET' style='display:inline'>";
+    echo "<input type='hidden' name='view' value='Recordings'>";
+    echo "<input type='hidden' name='species' value=\"" . htmlspecialchars($_GET['species'], ENT_QUOTES) . "\">";
+    if(isset($_GET['sort'])) {
+      echo "<input type='hidden' name='sort' value=\"" . htmlspecialchars($_GET['sort'], ENT_QUOTES) . "\">";
+    }
+    if(isset($_GET['only_excluded'])) {
+      echo "<input type='hidden' name='only_excluded' value='" . $_GET['only_excluded'] . "'>";
+    }
+    if(isset($_SESSION['date'])) {
+      echo "<input type='hidden' name='date' value='" . $_SESSION['date'] . "'>";
+    }
+    echo "<input type='hidden' name='limit' value='" . ($limit + 40) . "'>";
+    echo "<button type='submit' class='loadmore'>Load 40 more...</button>";
+    echo "</form>";
+    echo "</div>";
+  }
 
   if(isset($_GET['filename'])){
     $name = $_GET['filename'];


### PR DESCRIPTION
Issue : currently when there is a high number of recordings (I have 3k recordings on my disk for my top bird), the browsers try to load all spectrograms leading to high memory usage and blocking playback until everything is buffered

Proposal : new toggle to limit by default to top 50 recordings - anyway who needs more than this.

Advantages : MUCH faster opening for the different species. The code is aligned with pre-existing code.

![image](https://github.com/user-attachments/assets/ffe36815-96ae-4610-8cd5-c34b72c8f567)
