### PR TITLE
Load progress bar after image on audio player

### DIFF
--- a/homepage/static/custom-audio-player.js
+++ b/homepage/static/custom-audio-player.js
@@ -214,19 +214,21 @@ function initCustomAudioPlayers() {
       });
 
       // Dark vertical progression bar
-      indicator = document.createElement("div");
-      applyStyles(indicator, {
-        position: "absolute",
-        top: "0",
-        bottom: "0",
-        // Start at left margin
-        left: CONFIG.LEFT_MARGIN_PERCENT + "%",
-        width: "2px",
-        background: "rgba(0,0,0,0.8)",
-        pointerEvents: "none",
-        borderRadius: "2px",
+      img.addEventListener("load", () => {
+        indicator = document.createElement("div");
+        applyStyles(indicator, {
+          position: "absolute",
+          top: "0",
+          bottom: "0",
+          // Start at left margin
+          left: CONFIG.LEFT_MARGIN_PERCENT + "%",
+          width: "2px",
+          background: "rgba(0,0,0,0.8)",
+          pointerEvents: "none",
+          borderRadius: "2px",
+        });
+        wrapper.appendChild(indicator);
       });
-      wrapper.appendChild(indicator);
     }
 
     // Loading spinner

--- a/homepage/static/custom-audio-player.js
+++ b/homepage/static/custom-audio-player.js
@@ -407,7 +407,7 @@ function initCustomAudioPlayers() {
       position: "absolute",
       left: "0",
       bottom: "0",
-      z-index: "1",
+      zIndex: 1,
       width: "100%",
       height: "15%",
       display: "none",

--- a/homepage/static/custom-audio-player.js
+++ b/homepage/static/custom-audio-player.js
@@ -407,6 +407,7 @@ function initCustomAudioPlayers() {
       position: "absolute",
       left: "0",
       bottom: "0",
+      z-index: "1",
       width: "100%",
       height: "15%",
       display: "none",


### PR DESCRIPTION
Currently the progress bar is visible while loading the image. This fixes this providing a cleaner look 