### PR TITLE
Bugfix: whitelist_species_list.txt will now overrule the Species Occurrence Frequency Threshold

### DIFF
--- a/scripts/server.py
+++ b/scripts/server.py
@@ -135,9 +135,6 @@ def predictSpeciesList(lat, lon, week):
             # if there's a custom user-made include list, we only want to use the species in that
             if (len(INCLUDE_LIST) == 0):
                 PREDICTED_SPECIES_LIST.append(s[1])
-    WHITELIST_LIST = loadCustomSpeciesList(os.path.expanduser("~/BirdNET-Pi/whitelist_species_list.txt"))
-    for species in WHITELIST_LIST:
-        PREDICTED_SPECIES_LIST.append(species)
 
 
 def loadCustomSpeciesList(path):

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -10,8 +10,8 @@ import numpy as np
 
 from utils.helpers import get_settings, Detection
 
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
-os.environ["CUDA_VISIBLE_DEVICES"] = ""
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+os.environ['CUDA_VISIBLE_DEVICES'] = ''
 
 try:
     import tflite_runtime.interpreter as tflite
@@ -21,7 +21,7 @@ except BaseException:
 log = logging.getLogger(__name__)
 
 
-userDir = os.path.expanduser("~")
+userDir = os.path.expanduser('~')
 INTERPRETER, M_INTERPRETER, INCLUDE_LIST, EXCLUDE_LIST = (None, None, None, None)
 PREDICTED_SPECIES_LIST = []
 model, priv_thresh, sf_thresh = (None, None, None)
@@ -36,11 +36,11 @@ def loadModel():
     global MDATA_INPUT_INDEX
     global CLASSES
 
-    log.info("LOADING TF LITE MODEL...")
+    log.info('LOADING TF LITE MODEL...')
 
     # Load TFLite model and allocate tensors.
     # model will either be BirdNET_GLOBAL_6K_V2.4_Model_FP16 (new) or BirdNET_6K_GLOBAL_MODEL (old)
-    modelpath = userDir + "/BirdNET-Pi/model/" + model + ".tflite"
+    modelpath = userDir + '/BirdNET-Pi/model/'+model+'.tflite'
     myinterpreter = tflite.Interpreter(model_path=modelpath, num_threads=2)
     myinterpreter.allocate_tensors()
 
@@ -49,19 +49,19 @@ def loadModel():
     output_details = myinterpreter.get_output_details()
 
     # Get input tensor index
-    INPUT_LAYER_INDEX = input_details[0]["index"]
+    INPUT_LAYER_INDEX = input_details[0]['index']
     if model == "BirdNET_6K_GLOBAL_MODEL":
-        MDATA_INPUT_INDEX = input_details[1]["index"]
-    OUTPUT_LAYER_INDEX = output_details[0]["index"]
+        MDATA_INPUT_INDEX = input_details[1]['index']
+    OUTPUT_LAYER_INDEX = output_details[0]['index']
 
     # Load labels
     CLASSES = []
-    labelspath = userDir + "/BirdNET-Pi/model/labels.txt"
-    with open(labelspath, "r") as lfile:
+    labelspath = userDir + '/BirdNET-Pi/model/labels.txt'
+    with open(labelspath, 'r') as lfile:
         for line in lfile.readlines():
-            CLASSES.append(line.replace("\n", ""))
+            CLASSES.append(line.replace('\n', ''))
 
-    log.info("LOADING DONE!")
+    log.info('LOADING DONE!')
 
     return myinterpreter
 
@@ -72,15 +72,13 @@ def loadMetaModel():
     global M_INPUT_LAYER_INDEX
     global M_OUTPUT_LAYER_INDEX
 
-    if get_settings().getint("DATA_MODEL_VERSION") == 2:
-        data_model = "BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite"
+    if get_settings().getint('DATA_MODEL_VERSION') == 2:
+        data_model = 'BirdNET_GLOBAL_6K_V2.4_MData_Model_V2_FP16.tflite'
     else:
-        data_model = "BirdNET_GLOBAL_6K_V2.4_MData_Model_FP16.tflite"
+        data_model = 'BirdNET_GLOBAL_6K_V2.4_MData_Model_FP16.tflite'
 
     # Load TFLite model and allocate tensors.
-    M_INTERPRETER = tflite.Interpreter(
-        model_path=os.path.join(userDir, "BirdNET-Pi/model", data_model)
-    )
+    M_INTERPRETER = tflite.Interpreter(model_path=os.path.join(userDir, 'BirdNET-Pi/model', data_model))
     M_INTERPRETER.allocate_tensors()
 
     # Get input and output tensors.
@@ -88,8 +86,8 @@ def loadMetaModel():
     output_details = M_INTERPRETER.get_output_details()
 
     # Get input tensor index
-    M_INPUT_LAYER_INDEX = input_details[0]["index"]
-    M_OUTPUT_LAYER_INDEX = output_details[0]["index"]
+    M_INPUT_LAYER_INDEX = input_details[0]['index']
+    M_OUTPUT_LAYER_INDEX = output_details[0]['index']
 
     log.info("loaded META model")
 
@@ -103,7 +101,7 @@ def predictFilter(lat, lon, week):
         loadMetaModel()
 
     # Prepare mdata as sample
-    sample = np.expand_dims(np.array([lat, lon, week], dtype="float32"), 0)
+    sample = np.expand_dims(np.array([lat, lon, week], dtype='float32'), 0)
 
     # Run inference
     M_INTERPRETER.set_tensor(M_INPUT_LAYER_INDEX, sample)
@@ -135,11 +133,9 @@ def predictSpeciesList(lat, lon, week):
     for s in l_filter:
         if s[0] >= float(sf_thresh):
             # if there's a custom user-made include list, we only want to use the species in that
-            if len(INCLUDE_LIST) == 0:
+            if (len(INCLUDE_LIST) == 0):
                 PREDICTED_SPECIES_LIST.append(s[1])
-    WHITELIST_LIST = loadCustomSpeciesList(
-        os.path.expanduser("~/BirdNET-Pi/whitelist_species_list.txt")
-    )
+    WHITELIST_LIST = loadCustomSpeciesList(os.path.expanduser("~/BirdNET-Pi/whitelist_species_list.txt"))
     for species in WHITELIST_LIST:
         PREDICTED_SPECIES_LIST.append(species)
 
@@ -148,9 +144,9 @@ def loadCustomSpeciesList(path):
 
     slist = []
     if os.path.isfile(path):
-        with open(path, "r") as csfile:
+        with open(path, 'r') as csfile:
             for line in csfile.readlines():
-                slist.append(line.replace("\r", "").replace("\n", ""))
+                slist.append(line.replace('\r', '').replace('\n', ''))
 
     return slist
 
@@ -160,7 +156,7 @@ def splitSignal(sig, rate, overlap, seconds=3.0, minlen=1.5):
     # Split signal with overlap
     sig_splits = []
     for i in range(0, len(sig), int((seconds - overlap) * rate)):
-        split = sig[i : i + int(seconds * rate)]
+        split = sig[i:i + int(seconds * rate)]
 
         # End of signal?
         if len(split) < int(minlen * rate):
@@ -169,7 +165,7 @@ def splitSignal(sig, rate, overlap, seconds=3.0, minlen=1.5):
         # Signal chunk too short? Fill with zeros.
         if len(split) < int(rate * seconds):
             temp = np.zeros((int(rate * seconds)))
-            temp[: len(split)] = split
+            temp[:len(split)] = split
             split = temp
 
         sig_splits.append(split)
@@ -179,15 +175,15 @@ def splitSignal(sig, rate, overlap, seconds=3.0, minlen=1.5):
 
 def readAudioData(path, overlap, sample_rate=48000):
 
-    log.info("READING AUDIO DATA...")
+    log.info('READING AUDIO DATA...')
 
     # Open file with librosa (uses ffmpeg or libav)
-    sig, rate = librosa.load(path, sr=sample_rate, mono=True, res_type="kaiser_fast")
+    sig, rate = librosa.load(path, sr=sample_rate, mono=True, res_type='kaiser_fast')
 
     # Split audio into 3-second chunks
     chunks = splitSignal(sig, rate, overlap)
 
-    log.info("READING DONE! READ %d CHUNKS.", len(chunks))
+    log.info('READING DONE! READ %d CHUNKS.', len(chunks))
 
     return chunks
 
@@ -217,9 +213,9 @@ def custom_sigmoid(x, sensitivity=1.0):
 def predict(sample, sensitivity):
     global INTERPRETER
     # Make a prediction
-    INTERPRETER.set_tensor(INPUT_LAYER_INDEX, np.array(sample[0], dtype="float32"))
+    INTERPRETER.set_tensor(INPUT_LAYER_INDEX, np.array(sample[0], dtype='float32'))
     if model == "BirdNET_6K_GLOBAL_MODEL":
-        INTERPRETER.set_tensor(MDATA_INPUT_INDEX, np.array(sample[1], dtype="float32"))
+        INTERPRETER.set_tensor(MDATA_INPUT_INDEX, np.array(sample[1], dtype='float32'))
     INTERPRETER.invoke()
     prediction = INTERPRETER.get_tensor(OUTPUT_LAYER_INDEX)[0]
 
@@ -238,34 +234,21 @@ def predict(sample, sensitivity):
     log.debug("HUMAN-CUTOFF AT: %d", human_cutoff)
 
     for i in range(min(10, len(p_sorted))):
-        if p_sorted[i][0] == "Human_Human":
-            with open(userDir + "/BirdNET-Pi/HUMAN.txt", "a") as rfile:
-                rfile.write(
-                    str(datetime.datetime.now())
-                    + str(p_sorted[i])
-                    + " "
-                    + str(human_cutoff)
-                    + "\n"
-                )
+        if p_sorted[i][0] == 'Human_Human':
+            with open(userDir + '/BirdNET-Pi/HUMAN.txt', 'a') as rfile:
+                rfile.write(str(datetime.datetime.now()) + str(p_sorted[i]) + ' ' + str(human_cutoff) + '\n')
 
     return p_sorted[:human_cutoff]
 
 
-def analyzeAudioData(
-    chunks,
-    lat,
-    lon,
-    week,
-    sens,
-    overlap,
-):
+def analyzeAudioData(chunks, lat, lon, week, sens, overlap,):
     global INTERPRETER
 
     sensitivity = max(0.5, min(1.0 - (sens - 1.0), 1.5))
 
     detections = {}
     start = time.time()
-    log.info("ANALYZING AUDIO...")
+    log.info('ANALYZING AUDIO...')
 
     if model == "BirdNET_GLOBAL_6K_V2.4_Model_FP16":
         if len(PREDICTED_SPECIES_LIST) == 0 or len(INCLUDE_LIST) != 0:
@@ -282,7 +265,7 @@ def analyzeAudioData(
 
         # Make prediction
         p = predict([sig, mdata], sensitivity)
-        #        print("PPPPP",p)
+#        print("PPPPP",p)
         HUMAN_DETECTED = False
 
         # Catch if Human is recognized
@@ -295,13 +278,13 @@ def analyzeAudioData(
 
         # If human detected set all detections to human to make sure voices are not saved
         if HUMAN_DETECTED is True:
-            p = [("Human_Human", 0.0)] * 10
+            p = [('Human_Human', 0.0)] * 10
 
-        detections[str(pred_start) + ";" + str(pred_end)] = p
+        detections[str(pred_start) + ';' + str(pred_end)] = p
 
         pred_start = pred_end - overlap
 
-    log.info("DONE! Time %.2f SECONDS", time.time() - start)
+    log.info('DONE! Time %.2f SECONDS', time.time() - start)
     return detections
 
 
@@ -320,68 +303,46 @@ def load_global_model():
     global INTERPRETER
     global model, priv_thresh, sf_thresh
     conf = get_settings()
-    model = conf["MODEL"]
-    priv_thresh = conf.getfloat("PRIVACY_THRESHOLD")
-    sf_thresh = conf.getfloat("SF_THRESH")
+    model = conf['MODEL']
+    priv_thresh = conf.getfloat('PRIVACY_THRESHOLD')
+    sf_thresh = conf.getfloat('SF_THRESH')
     INTERPRETER = loadModel()
 
 
 def run_analysis(file):
     global INCLUDE_LIST, EXCLUDE_LIST, WHITELIST_LIST
-    INCLUDE_LIST = loadCustomSpeciesList(
-        os.path.expanduser("~/BirdNET-Pi/include_species_list.txt")
-    )
-    EXCLUDE_LIST = loadCustomSpeciesList(
-        os.path.expanduser("~/BirdNET-Pi/exclude_species_list.txt")
-    )
-    WHITELIST_LIST = loadCustomSpeciesList(
-        os.path.expanduser("~/BirdNET-Pi/whitelist_species_list.txt")
-    )
+    INCLUDE_LIST = loadCustomSpeciesList(os.path.expanduser("~/BirdNET-Pi/include_species_list.txt"))
+    EXCLUDE_LIST = loadCustomSpeciesList(os.path.expanduser("~/BirdNET-Pi/exclude_species_list.txt"))
+    WHITELIST_LIST = loadCustomSpeciesList(os.path.expanduser("~/BirdNET-Pi/whitelist_species_list.txt"))
 
     conf = get_settings()
 
     # Read audio data & handle errors
     try:
-        audio_data = readAudioData(file.file_name, conf.getfloat("OVERLAP"))
+        audio_data = readAudioData(file.file_name, conf.getfloat('OVERLAP'))
     except (NameError, TypeError) as e:
         log.error("Error with the following info: %s", e)
         return []
 
     # Process audio data and get detections
-    raw_detections = analyzeAudioData(
-        audio_data,
-        conf.getfloat("LATITUDE"),
-        conf.getfloat("LONGITUDE"),
-        file.week,
-        conf.getfloat("SENSITIVITY"),
-        conf.getfloat("OVERLAP"),
-    )
+    raw_detections = analyzeAudioData(audio_data, conf.getfloat('LATITUDE'), conf.getfloat('LONGITUDE'), file.week,
+                                      conf.getfloat('SENSITIVITY'), conf.getfloat('OVERLAP'))
     confident_detections = []
     for time_slot, entries in raw_detections.items():
-        log.info("%s-%s", time_slot, entries[0])
+        log.info('%s-%s', time_slot, entries[0])
         for entry in entries:
-            if entry[1] >= conf.getfloat("CONFIDENCE"):
+            if entry[1] >= conf.getfloat('CONFIDENCE'):
                 if entry[0] not in INCLUDE_LIST and len(INCLUDE_LIST) != 0:
-                    log.warning(
-                        "Excluded as INCLUDE_LIST is active but this species is not in it: %s",
-                        entry[0],
-                    )
+                    log.warning("Excluded as INCLUDE_LIST is active but this species is not in it: %s", entry[0])
                 elif entry[0] in EXCLUDE_LIST and len(EXCLUDE_LIST) != 0:
                     log.warning("Excluded as species in EXCLUDE_LIST: %s", entry[0])
-                elif (
-                    entry[0] not in PREDICTED_SPECIES_LIST
-                    and len(PREDICTED_SPECIES_LIST) != 0
-                    and entry[0] not in WHITELIST_LIST
-                ):
-                    log.warning(
-                        "Excluded as below Species Occurrence Frequency Threshold: %s",
-                        entry[0],
-                    )
+                elif entry[0] not in PREDICTED_SPECIES_LIST and len(PREDICTED_SPECIES_LIST) != 0 and entry[0] not in WHITELIST_LIST:
+                    log.warning("Excluded as below Species Occurrence Frequency Threshold: %s", entry[0])
                 else:
                     d = Detection(
                         file.file_date,
-                        time_slot.split(";")[0],
-                        time_slot.split(";")[1],
+                        time_slot.split(';')[0],
+                        time_slot.split(';')[1],
                         entry[0],
                         entry[1],
                     )


### PR DESCRIPTION
I have owls nearby that somehow have a very low Species Occurrence Frequency Threshold and get discarded. I don't want to lower the overall threshold where it will incorrectly start detecting rare birds. I'd like an exception for the owls I know that are nearby. The whitelist should be the system to do so, however, it was never implemented in `server.py`.

Similar to: https://github.com/Nachtzuster/BirdNET-Pi/discussions/265