### PR TITLE
Adding check for position and week that triggers re-creation of predicted species list

### DIFF
--- a/scripts/server.py
+++ b/scripts/server.py
@@ -20,10 +20,10 @@ except BaseException:
 
 
 class PositionAndWeek():
-    def __init__(self, lat, long):
-        self.lat = lat
-        self.long = long
-        self.weeknum = datetime.datetime.now().isocalendar().week
+    def __init__(self):
+        self.lat = None
+        self.long = None
+        self.weeknum = None
 
 
     def isPositionOrWeekChanged(self, lat, long):
@@ -38,7 +38,7 @@ class PositionAndWeek():
 
 
 log = logging.getLogger(__name__)
-paw = PositionAndWeek(0, 0)
+paw = PositionAndWeek()
 
 userDir = os.path.expanduser('~')
 INTERPRETER, M_INTERPRETER, INCLUDE_LIST, EXCLUDE_LIST = (None, None, None, None)

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -18,8 +18,27 @@ try:
 except BaseException:
     from tensorflow import lite as tflite
 
-log = logging.getLogger(__name__)
 
+class PositionAndWeek():
+    def __init__(self, lat, long):
+        self.lat = lat
+        self.long = long
+        self.weeknum = datetime.datetime.now().isocalendar().week
+
+
+    def isPositionOrWeekChanged(self, lat, long):
+        currentWeek = datetime.datetime.now().isocalendar().week
+        if (lat != self.lat) or (long != self.long) or (self.weeknum != currentWeek):
+            self.lat = lat
+            self.long = long
+            self.weeknum = currentWeek
+            return True
+        else:
+            return False
+
+
+log = logging.getLogger(__name__)
+paw = PositionAndWeek(0, 0)
 
 userDir = os.path.expanduser('~')
 INTERPRETER, M_INTERPRETER, INCLUDE_LIST, EXCLUDE_LIST = (None, None, None, None)
@@ -248,7 +267,7 @@ def analyzeAudioData(chunks, lat, lon, week, sens, overlap,):
     log.info('ANALYZING AUDIO...')
 
     if model == "BirdNET_GLOBAL_6K_V2.4_Model_FP16":
-        if len(PREDICTED_SPECIES_LIST) == 0 or len(INCLUDE_LIST) != 0:
+        if paw.isPositionOrWeekChanged(lat, lon) or len(INCLUDE_LIST) != 0:
             predictSpeciesList(lat, lon, week)
 
     mdata = get_metadata(lat, lon, week)

--- a/test/test_server_position_and_week.py
+++ b/test/test_server_position_and_week.py
@@ -1,0 +1,67 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import datetime
+from server import PositionAndWeek
+
+# Run these tests from the `scripts` folder: $ python3 -m unittest discover ../test
+
+class TestPositionAndWeek(unittest.TestCase):
+    def test_nothing_changed(self):
+        paw = PositionAndWeek(1, 2)
+        self.assertFalse(paw.isPositionOrWeekChanged(1, 2))
+
+    def test_updated_latitude(self):
+        paw = PositionAndWeek(1, 2)
+        self.assertTrue(paw.isPositionOrWeekChanged(0, 2))
+
+    def test_updated_longitude(self):
+        paw = PositionAndWeek(1, 2)
+        self.assertTrue(paw.isPositionOrWeekChanged(1, 0))
+
+    def test_check_second_call_after_update(self):
+        paw = PositionAndWeek(1, 2)
+        paw.isPositionOrWeekChanged(0, 2)
+        self.assertFalse(paw.isPositionOrWeekChanged(0, 2))
+
+
+    @patch('server.datetime')
+    def test_week_change(self, mock_datetime_module):
+        mock_datetime = MagicMock()
+
+        initial_date = datetime.datetime(2025, 6, 1)
+        changed_date = datetime.datetime(2025, 3, 1)
+
+        # First call return initial_date, second call return changed_date
+        mock_datetime.now.side_effect = [
+            MagicMock(isocalendar=lambda: initial_date.isocalendar()),
+            MagicMock(isocalendar=lambda: changed_date.isocalendar())
+        ]
+        mock_datetime_module.datetime = mock_datetime
+
+        paw = PositionAndWeek(1, 2)
+        changed = paw.isPositionOrWeekChanged(1, 2)
+
+        self.assertTrue(changed)
+
+
+    @patch('server.datetime')
+    def test_different_year_same_week(self, mock_datetime_module):
+        mock_datetime = MagicMock()
+
+        initial_date = datetime.datetime(2020, 1, 1)
+        changed_date = datetime.datetime(2025, 1, 1)
+
+        # First call return initial_date, second call return changed_date
+        mock_datetime.now.side_effect = [
+            MagicMock(isocalendar=lambda: initial_date.isocalendar()),
+            MagicMock(isocalendar=lambda: changed_date.isocalendar())
+        ]
+        mock_datetime_module.datetime = mock_datetime
+
+        obj = PositionAndWeek(1, 2)
+        changed = obj.isPositionOrWeekChanged(1, 2)
+
+        self.assertFalse(changed)
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_server_position_and_week.py
+++ b/test/test_server_position_and_week.py
@@ -6,23 +6,19 @@ from server import PositionAndWeek
 # Run these tests from the `scripts` folder: $ python3 -m unittest discover ../test
 
 class TestPositionAndWeek(unittest.TestCase):
-    def test_nothing_changed(self):
-        paw = PositionAndWeek(1, 2)
+    def test_calling_first_time(self):
+        paw = PositionAndWeek()
+        self.assertTrue(paw.isPositionOrWeekChanged(1, 2))
+
+    def test_calling_two_times_same_position(self):
+        paw = PositionAndWeek()
+        self.assertTrue(paw.isPositionOrWeekChanged(1, 2))
         self.assertFalse(paw.isPositionOrWeekChanged(1, 2))
 
-    def test_updated_latitude(self):
-        paw = PositionAndWeek(1, 2)
+    def test_calling_two_times_updated_position(self):
+        paw = PositionAndWeek()
+        self.assertTrue(paw.isPositionOrWeekChanged(1, 2))
         self.assertTrue(paw.isPositionOrWeekChanged(0, 2))
-
-    def test_updated_longitude(self):
-        paw = PositionAndWeek(1, 2)
-        self.assertTrue(paw.isPositionOrWeekChanged(1, 0))
-
-    def test_check_second_call_after_update(self):
-        paw = PositionAndWeek(1, 2)
-        paw.isPositionOrWeekChanged(0, 2)
-        self.assertFalse(paw.isPositionOrWeekChanged(0, 2))
-
 
     @patch('server.datetime')
     def test_week_change(self, mock_datetime_module):
@@ -38,7 +34,8 @@ class TestPositionAndWeek(unittest.TestCase):
         ]
         mock_datetime_module.datetime = mock_datetime
 
-        paw = PositionAndWeek(1, 2)
+        paw = PositionAndWeek()
+        dummy = paw.isPositionOrWeekChanged(1, 2) # First call is always true
         changed = paw.isPositionOrWeekChanged(1, 2)
 
         self.assertTrue(changed)
@@ -58,8 +55,9 @@ class TestPositionAndWeek(unittest.TestCase):
         ]
         mock_datetime_module.datetime = mock_datetime
 
-        obj = PositionAndWeek(1, 2)
-        changed = obj.isPositionOrWeekChanged(1, 2)
+        paw = PositionAndWeek()
+        dummy = paw.isPositionOrWeekChanged(1, 2) # First call is always true
+        changed = paw.isPositionOrWeekChanged(1, 2)
 
         self.assertFalse(changed)
         


### PR DESCRIPTION
DO NOT MERGE: I haven't tested this on my production system yet.

As an alternative to https://github.com/Nachtzuster/BirdNET-Pi/pull/371. This pull request uses a class and has testcode instead of using globals.
You can either merge request 371 or this one.