### PR TITLE
Convert birdweather uploads to flac

### DIFF
--- a/scripts/utils/reporting.py
+++ b/scripts/utils/reporting.py
@@ -179,14 +179,15 @@ def bird_weather(file: ParseFileName, detections: [Detection]):
         except Exception as e:
             log.error("Error during FLAC conversion: %s", e)
             return
+        gzip_flac_data = gzip.compress(flac_data)
 
         # POST soundscape to server
         soundscape_url = (f'https://app.birdweather.com/api/v1/stations/'
                           f'{conf["BIRDWEATHER_ID"]}/soundscapes?timestamp={file.iso8601}')
 
         try:
-            response = requests.post(url=soundscape_url, data=flac_data, timeout=30,
-                                     headers={'Content-Type': 'audio/flac'})
+            response = requests.post(url=soundscape_url, data=gzip_flac_data, timeout=30,
+                                     headers={'Content-Type': 'application/octet-stream', 'Content-Encoding': 'gzip'})
             log.info("Soundscape POST Response Status - %d", response.status_code)
             sdata = response.json()
         except BaseException as e:


### PR DESCRIPTION
Fixes : https://github.com/Nachtzuster/BirdNET-Pi/issues/394

See discussion https://github.com/Nachtzuster/BirdNET-Pi/discussions/390

Align with new birdweather requirement. Uses a python method without intermediate data writing.

The implementation only impacts files that are uploaded - the recording is still done in wav, and the user can use whatever format they want such as mp3