### PR TITLE
Fix: handle species with apostrophes in Apprise notification filters

### DIFF
--- a/scripts/utils/notifications.py
+++ b/scripts/utils/notifications.py
@@ -135,7 +135,7 @@ def sendAppriseNotifications(species, confidence, confidencepct, path,
                 today = datetime.now().strftime("%Y-%m-%d")
                 cur.execute(f"SELECT DISTINCT(Com_Name), COUNT(Com_Name) FROM detections WHERE Date = DATE('{today}') GROUP BY Com_Name")
                 known_species = cur.fetchall()
-                detections = [d[1] for d in known_species if d[0] == comName.replace("'", "")]
+                detections = [d[1] for d in known_species if d[0].replace("'", "") == comName.replace("'", "")]
                 numberDetections = 0
                 if len(detections):
                     numberDetections = detections[0]
@@ -158,7 +158,7 @@ def sendAppriseNotifications(species, confidence, confidencepct, path,
                 today = datetime.now().strftime("%Y-%m-%d")
                 cur.execute(f"SELECT DISTINCT(Com_Name), COUNT(Com_Name) FROM detections WHERE Date >= DATE('{today}', '-7 day') GROUP BY Com_Name")
                 known_species = cur.fetchall()
-                detections = [d[1] for d in known_species if d[0] == comName.replace("'", "")]
+                detections = [d[1] for d in known_species if d[0].replace("'", "") == comName.replace("'", "")]
                 numberDetections = 0
                 if len(detections):
                     numberDetections = detections[0]


### PR DESCRIPTION
## Fix: Correct species name matching for notifications involving apostrophes

###  Bug Overview

Apprise notifications controlled by variables such as `APPRISE_NOTIFY_NEW_SPECIES_EACH_DAY` and `APPRISE_NOTIFY_NEW_SPECIES` silently fail for species whose common names contain an apostrophe (e.g., **Abert's Towhee**, **Brewer's Sparrow**, etc.). 

This is due to inconsistent string sanitization in the logic that compares detected species names to database entries.

### Root Cause

The current comparison logic removes apostrophes from `comName`, but not from the `Com_Name` values returned from the SQLite database. As a result, the string comparison fails:

```python
    comName.replace("'", "") = "Aberts Towhee"
    database value            = "Abert's Towhee"
```

These do not match, so the detection is not counted properly and no notification is sent.

###  Fix

This PR updates the comparison logic to normalize both the database value and the `comName` by removing apostrophes on both sides:

**Before:**

    detections = [d[1] for d in known_species if d[0] == comName.replace("'", "")]

**After:**

    detections = [d[1] for d in known_species if d[0].replace("'", "") == comName.replace("'", "")]

This ensures that species names containing apostrophes are treated consistently during filtering and can trigger notifications as intended.

### Demonstration

```python
import sqlite3
from datetime import datetime

# Path to the BirdNET-Pi detections database
db_path = "scripts/birds.db"  # Adjust if necessary

# Get today's date
today = datetime.now().strftime("%Y-%m-%d")

# Connect to the database
con = sqlite3.connect(db_path)
cur = con.cursor()

# Query all distinct species detected today
cur.execute("""
    SELECT DISTINCT(Com_Name), COUNT(Com_Name)
    FROM detections
    WHERE Date = DATE(?)
    GROUP BY Com_Name
""", (today,))
rows = cur.fetchall()

# Print all species names returned
for row in rows:
    print(f"DB Com_Name: '{row[0]}'")

# Simulate the matching logic
comName = "Abert's Towhee"

# Old logic (only removes apostrophes from comName)
matches_old = [d[1] for d in rows if d[0] == comName.replace("'", "")]
print("Old logic match:", matches_old)

# New logic (removes apostrophes from both sides)
matches_new = [d[1] for d in rows if d[0].replace("'", "") == comName.replace("'", "")]
print("New logic match:", matches_new)
```
Output:
```text
$ python ./db_test.py
DB Com_Name: 'Abert's Towhee'
Old logic match: []
New logic match: [34]
```

### Impact

- Fixes a class of silent notification failures
- Affects only the matching logic used in notification filtering
- Verified using the species `"Abert's Towhee"` which previously had confirmed detections but no notifications
