### PR TITLE
Set artwork, title, and comment on MP3 file outputs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ inotify
 requests
 matplotlib
 pillow
+eyed3


### PR DESCRIPTION
This PR adds the following to ID3 metadata on MP3 recordings:

- spectrogram as front cover artwork
- species name and confidence percent as title
- confidence percent and model name as comment

A sample output MP3, with this metadata attached: https://dropbox.dzombak.com/ghimages/American_Goldfinch-50-2025-08-01-birdnet-08_00_12.mp3