### PR TITLE
enables raw/minimalist spectograms

### DIFF
--- a/scripts/spectrogram.sh
+++ b/scripts/spectrogram.sh
@@ -25,7 +25,13 @@ while read; do
 
     if [ -n "${analyzing_now}" ] && [ -f "${analyzing_now}" ]; then
       spectrogram_png=${EXTRACTED}/spectrogram.png
-      sox -V1 "${analyzing_now}" -n remix 1 rate 24k spectrogram -c "${analyzing_now//$HOME\//}" -o "${spectrogram_png}"
+        # Check if RAW_SPECTROGRAM is 1
+        if [ "$RAW_SPECTROGRAM" == "1" ]; then
+          # If it is, add "-r" as an argument to the SOX command
+          sox -V1 "${analyzing_now}" -n remix 1 rate 24k spectrogram -c "${analyzing_now//$HOME\//}" -o "${spectrogram_png}" -r
+        else
+          sox -V1 "${analyzing_now}" -n remix 1 rate 24k spectrogram -c "${analyzing_now//$HOME\//}" -o "${spectrogram_png}"
+        fi
     fi
     next=$(( now + looptime ))
   fi

--- a/scripts/utils/reporting.py
+++ b/scripts/utils/reporting.py
@@ -45,12 +45,13 @@ def extract_safe(in_file, out_file, start, stop):
     extract(in_file, out_file, safe_start, safe_stop)
 
 
-def spectrogram(in_file, title, comment, raw=False):
+def spectrogram(in_file, title, comment, raw=0):
     fd, tmp_file = tempfile.mkstemp(suffix='.png')
     os.close(fd)
     args = ['sox', '-V1', f'{in_file}', '-n', 'remix', '1', 'rate', '24k', 'spectrogram',
             '-t', '', '-c', '', '-o', tmp_file]
-    args += ['-r'] if raw else []
+    args += ['-r'] if int(raw) else []
+        
     result = subprocess.run(args, check=True, capture_output=True)
     ret = result.stdout.decode('utf-8')
     err = result.stderr.decode('utf-8')
@@ -81,7 +82,7 @@ def extract_detection(file: ParseFileName, detection: Detection):
     else:
         os.makedirs(new_dir, exist_ok=True)
         extract_safe(file.file_name, new_file, detection.start, detection.stop)
-        spectrogram(new_file, detection.common_name, new_file.replace(os.path.expanduser('~/'), ''))
+        spectrogram(new_file, detection.common_name, new_file.replace(os.path.expanduser('~/'), ''), conf['RAW_SPECTROGRAM'])
     return new_file
 
 


### PR DESCRIPTION
As raised in discussions here: https://github.com/Nachtzuster/BirdNET-Pi/discussions/434 the minimalist spectogram functionality wasn't working since "forever" (@Nachtzuster)

This PR resolves that and enables them as per the screenshot below (when enabled in settings)

<img width="877" height="1659" alt="image" src="https://github.com/user-attachments/assets/c91de828-1654-4dbb-b365-6e787fc65089" />
