### PR TITLE
Update apprise version to 1.9.5 to get Bluesky support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pandas
 seaborn
 streamlit==1.44.0
 plotly
-apprise==1.9.0
+apprise==1.9.5
 paho-mqtt<2.0.0
 pytest==7.1.2
 suntime==1.3.2


### PR DESCRIPTION
Would like to have Bluesky support in the Apprise version used in Birdnet-Pi, which is missing just now