### PR TITLE
Fix https://github.com/Nachtzuster/BirdNET-Pi/issues/504

### DIFF
--- a/scripts/server.py
+++ b/scripts/server.py
@@ -11,7 +11,7 @@ from utils.helpers import get_settings, Detection
 
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 os.environ['CUDA_VISIBLE_DEVICES'] = ''
-np.set_printoptions(legacy="1.25")
+np.set_printoptions(legacy="1.21")
 
 try:
     import tflite_runtime.interpreter as tflite


### PR DESCRIPTION
Fix https://github.com/Nachtzuster/BirdNET-Pi/issues/504
Use legacy 1.21 for numpy ; we could also use 1.13