### PR TITLE
Add rtsp_transport tcp to play.php

### DIFF
--- a/scripts/play.php
+++ b/scripts/play.php
@@ -106,7 +106,7 @@ if(isset($_GET['shiftfile'])) {
   $freqshift_tool = $config['FREQSHIFT_TOOL'];
 
   if ($freqshift_tool == "ffmpeg") {
-    $cmd = "sudo /usr/bin/nohup /usr/bin/ffmpeg -y -i ".escapeshellarg($pi.$filename)." -af \"rubberband=pitch=".$config['FREQSHIFT_LO']."/".$config['FREQSHIFT_HI']."\" ".escapeshellarg($shifted_path.$filename)."";
+    $cmd = "sudo /usr/bin/nohup /usr/bin/ffmpeg -rtsp_transport tcp -y -i ".escapeshellarg($pi.$filename)." -af \"rubberband=pitch=".$config['FREQSHIFT_LO']."/".$config['FREQSHIFT_HI']."\" ".escapeshellarg($shifted_path.$filename)."";
     shell_exec("sudo mkdir -p ".$shifted_path.$dir." && ".$cmd);
 
   } else if ($freqshift_tool == "sox") {


### PR DESCRIPTION
I've tried to use BirdNET-Pi with the project birdnetgo-esp32-rtsp-mic. Anyways, most of the ESP32 implementations will use TCP instead of UDP for RTSP. I've added it to the play.php script. In long-term, it would be nice to have this setting in the webinterface instead hard-coded.