### PR TITLE
Fix infinite retry loop for corrupted audio files

### DIFF
--- a/scripts/utils/analysis.py
+++ b/scripts/utils/analysis.py
@@ -149,8 +149,8 @@ def run_analysis(file):
     # Read audio data & handle errors
     try:
         audio_data = readAudioData(file.file_name, conf.getfloat('OVERLAP'), model.sample_rate, model.chunk_duration)
-    except (NameError, TypeError) as e:
-        log.error("Error with the following info: %s", e)
+    except Exception as e:
+        log.error("Error reading audio file %s: %s: %s", file.file_name, type(e).__name__, e)
         return []
 
     # Process audio data and get detections


### PR DESCRIPTION
Broaden exception handler in run_analysis() from (NameError, TypeError) to Exception to prevent infinite retry loops when librosa.load() fails.

Previous behavior:
- NameError/TypeError: file processed with empty detections, deleted
- Other exceptions (ValueError, RuntimeError, audioread.DecodeError): propagated to process_file(), file NOT deleted, retried on restart
- This caused infinite loops when a corrupted file kept failing

New behavior:
- All Python exceptions: file processed with empty detections, deleted
- Prevents infinite retry loops for corrupted/malformed audio files
- Improved logging: shows filename and exception type for debugging

This is a bug fix, not a breaking change. The "keep retrying forever" behavior for non-NameError/TypeError exceptions was unintended.

Note: C-level crashes (segfaults from ffmpeg/libsndfile) are still not catchable by Python manual intervention to delete corrupted files in the backlog