### PR TITLE
Add php-mbstring to installed dependencies

### DIFF
--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -17,7 +17,7 @@ install_depends() {
   curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
   apt -qqq update && apt -qqy upgrade
   echo "icecast2 icecast2/icecast-setup boolean false" | debconf-set-selections
-  apt install --no-install-recommends -qqy caddy sqlite3 php-sqlite3 php-fpm php-curl php-xml php-zip php icecast2 \
+  apt install --no-install-recommends -qqy caddy sqlite3 php-sqlite3 php-fpm php-curl php-xml php-zip php-mbstring php icecast2 \
     pulseaudio avahi-utils sox libsox-fmt-mp3 alsa-utils ffmpeg \
     wget curl unzip bc \
     python3-pip python3-venv lsof net-tools inotify-tools


### PR DESCRIPTION
## Summary

- Add `php-mbstring` to the apt install line in `install_services.sh`

phpSysInfo (Tools -> System Info) requires the mbstring PHP extension. Without it, the page displays:

> checkForExtensions phpSysInfo requires the mbstring extension to php in order to work properly.

Reproduced on a fresh install on Debian Trixie (arm64).

Fixes #531

## Test plan

- [ ] Fresh install on Debian Trixie includes php-mbstring
- [ ] Tools -> System Info loads without the mbstring error