### PR TITLE
Change Wikipedia thumbnail size to standard one

### DIFF
--- a/scripts/common.php
+++ b/scripts/common.php
@@ -450,8 +450,8 @@ class Wikipedia extends ImageProvider {
       } else {
         $license_url = $this->get_external_link($image_url);
       }
-      if ($page["imageinfo"][0]["width"] > 1024) {
-        $image_url = preg_replace('#/commons/#', '/commons/thumb/', $image_url) . '/1024px-'. $image_name;
+      if ($page["imageinfo"][0]["width"] > 1280) {
+        $image_url = preg_replace('#/commons/#', '/commons/thumb/', $image_url) . '/1280px-'. $image_name;
       }
     }
 


### PR DESCRIPTION
Wikipedia errors out on thumbnails with obsolete thumbnail resolutions with "Error: 429, Use thumbnail steps listed on https://w.wiki/GHai.".
This Indirectly fixes https://github.com/Nachtzuster/BirdNET-Pi/issues/568 and https://github.com/Nachtzuster/BirdNET-Pi/discussions/441.
Example image that is failing to load in BirdNET-Pi: https://upload.wikimedia.org/wikipedia/commons/thumb/6/6d/Tree_pipit_-_Jamnagar_2021-10-16.jpg/1024px-Tree_pipit_-_Jamnagar_2021-10-16.jpg