### PR TITLE
Bashrc not overwritten on BirdNET update

### DIFF
--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -291,11 +291,28 @@ EOF
   systemctl enable chart_viewer.service
 }
 
+install_bashrc() {
+  if [[ -L ${HOME}/.bashrc ]]; then
+    sudo -u ${USER} rm ${HOME}/.bashrc
+  fi
+
+  if [ ! -f ${HOME}/.bashrc ]; then
+    sudo -u ${USER} cp ${HOME}/BirdNET-Pi/templates/bashrc ${HOME}/.bashrc
+  else 
+    if ! grep -q "source ~/.birdnet_bashrc" ${HOME}/.bashrc; then
+      echo "# custom sourcing for BirdNET, please don't remove" >> ${HOME}/.bashrc
+      echo "source ~/.birdnet_bashrc" >> ${HOME}/.bashrc
+    fi
+  fi 
+
+  if [ ! -f ${HOME}/.birdnet_bashrc ]; then
+    sudo -u ${USER} ln -sf ${HOME}/BirdNET-Pi/templates/birdnet_bashrc ${HOME}/.birdnet_bashrc
+  fi
+}
+
 install_gotty_logs() {
   sudo -u ${USER} ln -sf $my_dir/templates/gotty \
     ${HOME}/.gotty
-  sudo -u ${USER} ln -sf $my_dir/templates/bashrc \
-    ${HOME}/.bashrc
   cat << EOF > $HOME/BirdNET-Pi/templates/birdnet_log.service
 [Unit]
 Description=BirdNET Analysis Log
@@ -418,6 +435,7 @@ install_services() {
   install_custom_recording_service # But does not enable
   install_spectrogram_service
   install_chart_viewer_service
+  install_bashrc
   install_gotty_logs
   install_phpsysinfo
   install_livestream_service

--- a/scripts/update_birdnet_snippets.sh
+++ b/scripts/update_birdnet_snippets.sh
@@ -14,6 +14,7 @@ else
 fi
 my_dir=$HOME/BirdNET-Pi/scripts
 source "$my_dir/install_helpers.sh"
+source "$my_dir/install_services.sh"
 
 # Sets proper permissions and ownership
 find $HOME/Bird* -type f ! -perm -g+wr -exec chmod g+wr {} + 2>/dev/null
@@ -244,6 +245,8 @@ fi
 if [ -L /usr/local/bin/birdnet_analysis.sh ];then
   rm -f /usr/local/bin/birdnet_analysis.sh
 fi
+
+install_bashrc
 
 # Clean state and update cron if all scripts are not installed
 if [ "$(grep -o "#birdnet" /etc/crontab | wc -l)" -lt 6 ]; then

--- a/templates/bashrc
+++ b/templates/bashrc
@@ -111,10 +111,11 @@ if ! shopt -oq posix; then
     . /etc/bash_completion
   fi
 fi
+
+# BirdNET default features that users can remove
 cd ~/BirdNET-Pi
-function remove() {
-  source /etc/birdnet/birdnet.conf
-  find $EXTRACTED -iname *${1}* -exec rm -drfv {} +
-}
 alias rerc="source ~/.bashrc"
 alias vimrc="vim ~/.bashrc"
+
+# custom sourcing for BirdNET, please don't remove
+source ~/.birdnet_bashrc

--- a/templates/birdnet_bashrc
+++ b/templates/birdnet_bashrc
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# BirdNET-Pi custom bashrc sourcing
+# DO NOT MODIFY THIS FILE
+
+function remove() {
+  source /etc/birdnet/birdnet.conf
+  find $EXTRACTED -iname *${1}* -exec rm -drfv {} +
+}
+


### PR DESCRIPTION
users can make changes to bashrc
bashrc verified on install and update, not overwritten
replaced bashrc symlink with cp
added custom sourcing solution for BirdNET related things


If the remove function in templates/birdnet_bashrc and other bashrc modifications are not really needed, consider not touching the user's bashrc at all.