### PR TITLE
Fix Database Locking Issues

### DIFF
--- a/scripts/birdnet_analysis.py
+++ b/scripts/birdnet_analysis.py
@@ -14,7 +14,7 @@ from inotify.constants import IN_CLOSE_WRITE
 from utils.analysis import load_global_model, run_analysis
 from utils.helpers import get_settings, get_wav_files, ANALYZING_NOW
 from utils.classes import ParseFileName
-from utils.reporting import extract_detection, summary, write_to_file, write_to_db, apprise, bird_weather, heartbeat, \
+from utils.reporting import extract_detection, summary, write_to_file, write_to_db, write_detections_to_db, apprise, bird_weather, heartbeat, \
     update_json_file
 
 shutdown = False
@@ -94,6 +94,7 @@ def process_file(file_name, report_queue):
         if not report_queue.empty():
             log.warning('reporting queue not yet empty')
         report_queue.join()
+        # Use batch insert to reduce database transactions and locking
         report_queue.put((file, detections))
     except BaseException as e:
         stderr = e.stderr.decode('utf-8') if isinstance(e, CalledProcessError) else ""
@@ -114,7 +115,7 @@ def handle_reporting_queue(queue):
                 detection.file_name_extr = extract_detection(file, detection)
                 log.info('%s;%s', summary(file, detection), os.path.basename(detection.file_name_extr))
                 write_to_file(file, detection)
-                write_to_db(file, detection)
+            write_detections_to_db(file, detections)  # Moved outside loop to avoid duplicate writes
             apprise(file, detections)
             bird_weather(file, detections)
             heartbeat()

--- a/scripts/common.php
+++ b/scripts/common.php
@@ -121,11 +121,12 @@ function get_label($record, $sort_by, $date=null) {
 }
 
 function get_db() {
-  if (!isset($_db)) {
-    $_db = new SQLite3('./scripts/birds.db', SQLITE3_OPEN_READONLY);
-    $_db->busyTimeout(1000);
+  static $db = null;
+  if ($db === null) {
+    $db = new SQLite3('./scripts/birds.db', SQLITE3_OPEN_READONLY);
+    $db->busyTimeout(1000);
   }
-  return $_db;
+  return $db;
 }
 
 function fetch_species_array($sort_by, $date=null) {

--- a/scripts/common.php
+++ b/scripts/common.php
@@ -124,7 +124,7 @@ function get_db() {
   static $db = null;
   if ($db === null) {
     $db = new SQLite3('./scripts/birds.db', SQLITE3_OPEN_READONLY);
-    $db->busyTimeout(1000);
+    $db->busyTimeout(5000);  // Increased from 1000ms to 5000ms
   }
   return $db;
 }
@@ -255,7 +255,7 @@ class ImageProvider {
     } catch (Exception $ex) {
       $this->create_tables();
     }
-    $this->db->busyTimeout(1000);
+    $this->db->busyTimeout(5000);
   }
 
   protected function create_tables() {

--- a/scripts/history.php
+++ b/scripts/history.php
@@ -19,7 +19,7 @@ $chart = "Combo-$theDate.png";
 $chart2 = "Combo2-$theDate.png";
 
 $db = new SQLite3('./scripts/birds.db', SQLITE3_OPEN_READONLY);
-$db->busyTimeout(1000);
+$db->busyTimeout(5000);
 
 $statement1 = $db->prepare("SELECT COUNT(*) FROM detections WHERE Date == \"$theDate\"");
 ensure_db_ok($statement1);

--- a/scripts/overview.php
+++ b/scripts/overview.php
@@ -13,7 +13,7 @@ $myDate = date('Y-m-d');
 $chart = "Combo-$myDate.png";
 
 $db = new SQLite3('./scripts/birds.db', SQLITE3_OPEN_READONLY);
-$db->busyTimeout(1000);
+$db->busyTimeout(5000);
 
 if(isset($_GET['custom_image'])){
   if(isset($config["CUSTOM_IMAGE"])) {

--- a/scripts/play.php
+++ b/scripts/play.php
@@ -12,7 +12,7 @@ $config = get_config();
 $user = get_user();
 
 $db = new SQLite3('./scripts/birds.db', SQLITE3_OPEN_READONLY);
-$db->busyTimeout(1000);
+$db->busyTimeout(5000);
 
 if(isset($_GET['deletefile'])) {
   ensure_authenticated('You must be authenticated to delete files.');
@@ -21,7 +21,7 @@ if(isset($_GET['deletefile'])) {
     die();
   }
   $db_writable = new SQLite3('./scripts/birds.db', SQLITE3_OPEN_READWRITE);
-  $db->busyTimeout(1000);
+  $db->busyTimeout(5000);
   $statement1 = $db_writable->prepare('DELETE FROM detections WHERE File_Name = :file_name LIMIT 1');
   ensure_db_ok($statement1);
   $statement1->bindValue(':file_name', explode("/", $_GET['deletefile'])[2]);

--- a/scripts/species_tools.php
+++ b/scripts/species_tools.php
@@ -33,7 +33,7 @@ if (isset($_GET['diskcounts'])) {
 /* ---------- DB open (RO unless deleting) ---------- */
 $flags = isset($_GET['delete']) ? SQLITE3_OPEN_READWRITE : SQLITE3_OPEN_READONLY;
 $db   = new SQLite3(__DIR__ . '/birds.db', $flags);
-$db->busyTimeout(1000);
+$db->busyTimeout(5000);
 
 /* Paths / lists */
 $base_symlink   = $home . '/BirdSongs/Extracted/By_Date';

--- a/scripts/todays_detections.php
+++ b/scripts/todays_detections.php
@@ -23,7 +23,7 @@ if(isset($kiosk) && $kiosk == true) {
 }
 
 $db = new SQLite3('./scripts/birds.db', SQLITE3_OPEN_READONLY);
-$db->busyTimeout(1000);
+$db->busyTimeout(5000);
 
 $summary = get_summary();
 $totalcount = $summary['totalcount'];

--- a/scripts/utils/reporting.py
+++ b/scripts/utils/reporting.py
@@ -112,6 +112,35 @@ def write_to_db(file: ParseFileName, detection: Detection):
             sleep(2)
 
 
+def write_detections_to_db(file: ParseFileName, detections: list):
+    """Batch insert multiple detections in a single transaction to reduce locking"""
+    conf = get_settings()
+    for attempt_number in range(3):
+        try:
+            con = sqlite3.connect(DB_PATH)
+            con.execute("PRAGMA journal_mode=WAL;")
+            con.execute("PRAGMA synchronous=NORMAL;")
+            cur = con.cursor()
+
+            # Start transaction
+            cur.execute("BEGIN TRANSACTION;")
+
+            # Insert all detections
+            for detection in detections:
+                cur.execute("INSERT INTO detections VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                            (detection.date, detection.time, detection.scientific_name, detection.common_name, detection.confidence,
+                             conf['LATITUDE'], conf['LONGITUDE'], conf['CONFIDENCE'], str(detection.week), conf['SENSITIVITY'],
+                             conf['OVERLAP'], os.path.basename(detection.file_name_extr)))
+
+            # Commit all at once
+            con.commit()
+            con.close()
+            break
+        except BaseException as e:
+            log.warning("Database busy: %s", e)
+            sleep(2)
+
+
 def summary(file: ParseFileName, detection: Detection):
     # Date;Time;Sci_Name;Com_Name;Confidence;Lat;Lon;Cutoff;Week;Sens;Overlap
     # 2023-03-03;12:48:01;Phleocryptes melanops;Wren-like Rushbird;0.76950216;-1;-1;0.7;9;1.25;0.0

--- a/scripts/utils/reporting.py
+++ b/scripts/utils/reporting.py
@@ -93,6 +93,8 @@ def write_to_db(file: ParseFileName, detection: Detection):
     for attempt_number in range(3):
         try:
             con = sqlite3.connect(DB_PATH)
+            con.execute("PRAGMA journal_mode=WAL;")
+            con.execute("PRAGMA synchronous=NORMAL;")
             cur = con.cursor()
             cur.execute("INSERT INTO detections VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                         (detection.date, detection.time, detection.scientific_name, detection.common_name, detection.confidence,

--- a/scripts/weekly_report.php
+++ b/scripts/weekly_report.php
@@ -23,7 +23,7 @@ function safe_percentage($count, $prior_count) {
 }
 
 $db = new SQLite3('./scripts/birds.db', SQLITE3_OPEN_READONLY);
-$db->busyTimeout(1000);
+$db->busyTimeout(5000);
 
 $statement1 = $db->prepare('SELECT Sci_Name, Com_Name, COUNT(*) FROM detections WHERE Date BETWEEN "' . date("Y-m-d", $startdate) . '" AND "' . date("Y-m-d", $enddate) . '" GROUP By Sci_Name ORDER BY COUNT(*) DESC');
 ensure_db_ok($statement1);


### PR DESCRIPTION
### Fix Database Locking Issues                                                                                                                                                                                                     
                                                                                                                                                                                                                                
Related Discussion: #323                                                                                                                                                                                                        
                                                                                                                                                                                                                                
This pull request addresses the "Database busy. database is locked" errors that occur when reloading pages while detections are being processed in the background.                                                              
                                                                                                                                                                                                                                
## Changes Included                                                                                                                                                                                                                
                                                                                                                                                                                                                                
1. Fix database connection leak in common.php (9b901b0)                                                                                                                                                                         
                                                                                                                                                                                                                                
• Fixed get_db() function that was creating new connections on every call                                                                                                                                                       
• Changed from broken global variable to static variable                                                                                                                                                                        
• Ensures only one connection per PHP request                                                                                                                                                                                   
                                                                                                                                                                                                                                
2. Enable WAL mode in Python reporting (2d86b93)                                                                                                                                                                                
                                                                                                                                                                                                                                
• Added PRAGMA journal_mode=WAL to allow concurrent reads during writes                                                                                                                                                         
• Set PRAGMA synchronous=NORMAL for better performance                                                                                                                                                                          
• Critical for applications with frequent writes and reads                                                                                                                                                                      
                                                                                                                                                                                                                                
3. Implement batch inserts (abb03ad)                                                                                                                                                                                            
                                                                                                                                                                                                                                
• Added write_detections_to_db() function for batch transactions                                                                                                                                                                
• Groups all detections from a file into single transaction                                                                                                                                                                     
• Reduces lock duration and improves concurrency                                                                                                                                                                                
                                                                                                                                                                                                                                
4. Increase busy timeout (ded7eed)                                                                                                                                                                                              
                                                                                                                                                                                                                                
• Increased timeout from 1s to 5s in all PHP scripts                                                                                                                                                                            
• Gives web interface more time to wait for write operations                                                                                                                                                                    
• Reduces "database is busy" errors                             

This PR has been crated with the help of mistral vibe AI.