### PR TITLE
docs: add BirdEcho mobile companion app to Cool Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ For more information : https://github.com/alexbelgium/hassio-addons/blob/master/
 - [RaspberryPi.com Blog Post](https://www.raspberrypi.com/news/classify-birds-acoustically-with-birdnet-pi/)
 - [MagPi Issue 119 Showcase Article](https://magpi.raspberrypi.com/issues/119/pdf)
 
+### Mobile Apps
+- [BirdEcho](https://github.com/arunrajiah/birdecho) — open-source Android/iOS companion app. Connects to your station via the BirdWeather API. Live detection feed, audio playback, species browser, 14-day chart, and local notifications for favourite species. MIT licensed.
+
 
 ### Internationalization:
 The bird names are in English by default, but other localized versions are available thanks to the wonderful efforts of [@patlevin](https://github.com/patlevin) and Wikipedia. Use the web interface's "Tools" > "Settings" and select your "Database Language" to have the detections in your language.


### PR DESCRIPTION
## What this changes

Adds a **Mobile Apps** subsection under Cool Links with a one-line entry for [BirdEcho](https://github.com/arunrajiah/birdecho) — an open-source mobile companion app for BirdNET-Pi stations.

## Proposed addition

```markdown
### Mobile Apps
- [BirdEcho](https://github.com/arunrajiah/birdecho) — open-source Android/iOS companion app. Connects directly to BirdNET-Go stations over your local network (no cloud account needed), or via the BirdWeather API for BirdNET-Pi and BirdWeather stations. Live detection feed, audio playback, species browser, 14-day chart, and local notifications for favourite species. MIT licensed.
```

## Notes

- **BirdNET-Pi users**: BirdEcho connects via the BirdWeather API, so BirdWeather integration must be enabled on the station (Tools → Settings → BirdWeather).
- **BirdNET-Go users** (as of v0.2.0): BirdEcho can connect directly over the local network with no BirdWeather account needed.
- It is not affiliated with or endorsed by the BirdNET-Pi project.
- Happy to adjust wording or placement to match the project's conventions.