### PR TITLE
fix: check re.search result before .group() in ParseFileName (issue #615)

### DIFF
--- a/scripts/utils/classes.py
+++ b/scripts/utils/classes.py
@@ -30,8 +30,15 @@ class ParseFileName:
     def __init__(self, file_name):
         self.file_name = file_name
         name = os.path.splitext(os.path.basename(file_name))[0]
-        date_created = re.search('^[0-9]+-[0-9]+-[0-9]+', name).group()
-        time_created = re.search('[0-9]+:[0-9]+:[0-9]+$', name).group()
+        date_match = re.search('^[0-9]+-[0-9]+-[0-9]+', name)
+        time_match = re.search('[0-9]+:[0-9]+:[0-9]+$', name)
+        if date_match is None or time_match is None:
+            raise ValueError(
+                f"Filename '{file_name}' does not match expected pattern "
+                f"YYYY-MM-DD-...-HH:MM:SS"
+            )
+        date_created = date_match.group()
+        time_created = time_match.group()
         self.file_date = datetime.datetime.strptime(f'{date_created}T{time_created}', "%Y-%m-%dT%H:%M:%S")
         self.root = name
 


### PR DESCRIPTION
## Summary

Fix `ParseFileName.__init__` crashing with `AttributeError: 'NoneType' object has no attribute 'group'` when a filename doesn't match the expected `YYYY-MM-DD-...-HH:MM:SS` pattern.

## Problem

`re.search()` returns `None` when the pattern doesn't match, but the code called `.group()` directly on the result without checking. This caused an `AttributeError` for any non-conforming filename in `StreamData`.

## Fix

Store `re.search()` results in variables and check for `None` before calling `.group()`. If either the date or time pattern doesn't match, raise a clear `ValueError` with the filename and expected pattern, instead of a cryptic `AttributeError`.

## Changes

- `scripts/utils/classes.py`: Added `None` checks for both `re.search()` calls in `ParseFileName.__init__`, raising `ValueError` with a descriptive message when the filename doesn't match the expected pattern.

## Testing

Verified that:
- Valid filenames (e.g., `2024-05-21 14:30:00.wav`) still parse correctly
- Invalid filenames (e.g., `foo.wav`) now raise `ValueError` with a clear message instead of `AttributeError`

Fixes #615