### PR TITLE
Add After=(e.g.)multi-user.target

### DIFF
--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -119,6 +119,7 @@ install_recording_service() {
   cat << EOF > $HOME/BirdNET-Pi/templates/birdnet_recording.service
 [Unit]
 Description=BirdNET Recording
+After=sound.target
 [Service]
 Restart=always
 Type=simple
@@ -137,6 +138,7 @@ install_custom_recording_service() {
   cat << EOF > $HOME/BirdNET-Pi/templates/custom_recording.service
 [Unit]
 Description=BirdNET Custom Recording
+After=sound.target
 [Service]
 Restart=always
 Type=simple


### PR DESCRIPTION
I am using a Raspi 3 B with a walimexPro BOYA M3 microphone (USB-C).
I am intending to use it outside in the field.
After booting, the "currently analyzing" field shows an empty spectogram - the recording service is recording silence.
I added an `After=sound.target` condition to my `birdnet_recording.service`-unit, so it waits for the detection of sound cards ->[(look in the manpage)](https://man7.org/linux/man-pages/man7/systemd.special.7.html) before starting `arecord` - now it works without restarting the recording service after every boot.
