### PR TITLE
Add authentication to File Manager and Adminer views

### DIFF
--- a/homepage/views.php
+++ b/homepage/views.php
@@ -209,9 +209,11 @@ if(isset($_GET['view'])){
     include('scripts/species_tools.php');
   }
   if($_GET['view'] == "File"){
+    ensure_authenticated();
     echo "<iframe src='scripts/filemanager/filemanager.php'></iframe>";
   }
   if($_GET['view'] == "Adminer"){
+    ensure_authenticated();
     echo "<iframe src='scripts/adminer.php'></iframe>";
   }
   if($_GET['view'] == "Webterm"){


### PR DESCRIPTION
The File Manager and Adminer views in views.php had no `ensure_authenticated()`
call, unlike every other privileged view (System Controls, Services, Webterm,
Species Management, etc.).

This means anyone who sets `CADDY_PWD` in `birdnet.conf` directly — a workaround
documented in multiple community issues [1][2] — ends up with PHP auth
enforced but Caddy's `basicauth` unchanged. The file manager at
`/scripts/filemanager/filemanager.php` remains accessible without credentials,
exposing `birdnet.conf` (including the plaintext `CADDY_PWD`) to unauthenticated
users.

Fix: add `ensure_authenticated()` before the File and Adminer includes,
consistent with how Webterm is already handled.

---

## Password Change Does Not Protect the File Manager

When a user sets a password by editing `/etc/birdnet/birdnet.conf` directly —
a documented community workaround recommended in multiple GitHub issues [1][2]
— `update_caddyfile.sh` is never called. `CADDY_PWD` is set, PHP requires the
password, but Caddy has no auth configured. The user confirms the login prompt
is working and believes the instance is secured. The file manager remains wide
open.

### How it plays out

1. User sets `CADDY_PWD=hunter2` in `/etc/birdnet/birdnet.conf`
2. PHP's auth starts requiring the password — user confirms it's working
3. Caddy's auth is never updated — either because `update_caddyfile.sh` was never run, or because it failed silently when called from the web interface (`caddy` is not in PHP's PATH, leaving `HASHWORD` empty and the generated Caddyfile malformed) — file manager remains accessible
4. Attacker recovers the plaintext password directly from `birdnet.conf`:

```bash
HOST="http://target"
USER=$(curl -s "$HOST/scripts/filemanager/filemanager.php?p=" \
  | grep -oE 'p=[a-z][a-z0-9_-]+' | head -1 | cut -d= -f2)
curl -s "$HOST/scripts/filemanager/filemanager.php?p=${USER}%2FBirdNET-Pi&dl=birdnet.conf" \
  | grep "CADDY_PWD"
```
```
CADDY_PWD=hunter2
```

5. Attacker uses the recovered password against authenticated RCE endpoints

[1] https://github.com/mcguirepr89/BirdNET-Pi/issues/889
[2] https://github.com/mcguirepr89/BirdNET-Pi/issues/749