### PR TITLE
fix: preserve JSON quotes in Apprise MQTT notifications

### DIFF
--- a/scripts/config.php
+++ b/scripts/config.php
@@ -63,7 +63,7 @@ if(isset($_GET["latitude"])){
   $birdweather_id = $_GET["birdweather_id"];
   $apprise_input = $_GET['apprise_input'];
   $apprise_notification_title = $_GET['apprise_notification_title'];
-  $apprise_notification_body = htmlspecialchars_decode($_GET['apprise_notification_body'], ENT_QUOTES);
+  $apprise_notification_body = html_entity_decode($_GET['apprise_notification_body'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
   $minimum_time_limit = $_GET['minimum_time_limit'];
   $image_provider = $_GET["image_provider"];
   $flickr_api_key = $_GET['flickr_api_key'];
@@ -199,7 +199,7 @@ if(isset($_GET["latitude"])){
 if(isset($_GET['sendtest']) && $_GET['sendtest'] == "true") {
   $conf = $_GET['apprise_config'];
   $title = $_GET['apprise_notification_title'];
-  $body = $_GET['apprise_notification_body'];
+  $body = html_entity_decode($_GET['apprise_notification_body'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
 
   $temp_conf = tmpfile();
   $t_conf_path = stream_get_meta_data($temp_conf)['uri'];
@@ -476,7 +476,7 @@ https://discordapp.com/api/webhooks/{WebhookID}/{WebhookToken}
       <label for="apprise_notification_title">Notification Title: </label>
       <input name="apprise_notification_title" style="width: 100%" type="text" value="<?php print($config['APPRISE_NOTIFICATION_TITLE']);?>" /><br>
       <label for="apprise_notification_body">Notification Body: </label>
-      <textarea class="testbtn" name="apprise_notification_body" rows="5" type="text" ><?php print($apprise_notification_body);?></textarea>
+      <textarea class="testbtn" name="apprise_notification_body" rows="5" type="text" ><?php print(htmlspecialchars($apprise_notification_body, ENT_QUOTES, 'UTF-8'));?></textarea>
       <input type="checkbox" name="apprise_notify_new_species" <?php if($config['APPRISE_NOTIFY_NEW_SPECIES'] == 1 && filesize($home."/BirdNET-Pi/apprise.txt") != 0) { echo "checked"; };?> >
       <label for="apprise_notify_new_species">Notify each new infrequent species detection (<5 visits per week)</label><br>
       <input type="checkbox" name="apprise_notify_new_species_each_day" <?php if($config['APPRISE_NOTIFY_NEW_SPECIES_EACH_DAY'] == 1 && filesize($home."/BirdNET-Pi/apprise.txt") != 0) { echo "checked"; };?> >

--- a/scripts/utils/notifications.py
+++ b/scripts/utils/notifications.py
@@ -59,8 +59,8 @@ def sendAppriseNotifications(sci_name, com_name, confidence, confidencepct, path
             .replace("$longitude", str(longitude)) \
             .replace("$cutoff", str(cutoff)) \
             .replace("$sens", str(sens)) \
-            .replace("$flickrimage", image_url if "{" in body else "") \
-            .replace("$image", image_url if "{" in body else "") \
+            .replace("$flickrimage", image_url if json_body else "") \
+            .replace("$image", image_url if json_body else "") \
             .replace("$overlap", str(overlap)) \
             .replace("$reason", reason)
         return ret
@@ -70,8 +70,12 @@ def sendAppriseNotifications(sci_name, com_name, confidence, confidencepct, path
 
     settings_dict = get_settings()
     title = html.unescape(settings_dict.get('APPRISE_NOTIFICATION_TITLE'))
-    f = open(APPRISE_BODY, 'r')
-    body = f.read()
+    with open(APPRISE_BODY, 'r') as f:
+        # Settings UI may persist HTML entities (e.g. &#34; for quotes)
+        body = html.unescape(f.read())
+
+    # Title-less services (MQTT) prepend title to body; omit it for JSON payloads
+    json_body = body.lstrip().startswith("{")
 
     websiteurl = settings_dict.get('BIRDNETPI_URL')
     if websiteurl is None or len(websiteurl) == 0:
@@ -94,7 +98,7 @@ def sendAppriseNotifications(sci_name, com_name, confidence, confidencepct, path
     if settings_dict.get('APPRISE_NOTIFY_EACH_DETECTION') == "1":
         reason = "detection"
         notify_body = render_template(body, reason)
-        notify_title = render_template(title, reason)
+        notify_title = "" if json_body else render_template(title, reason)
         notify(notify_body, notify_title, image_url)
         species_last_notified[com_name] = int(time.time())
 
@@ -104,7 +108,7 @@ def sendAppriseNotifications(sci_name, com_name, confidence, confidencepct, path
         if 0 < numberDetections <= APPRISE_NOTIFICATION_NEW_SPECIES_DAILY_COUNT_LIMIT:
             reason = "first time today"
             notify_body = render_template(body, reason)
-            notify_title = render_template(title, reason)
+            notify_title = "" if json_body else render_template(title, reason)
             notify(notify_body, notify_title, image_url)
             species_last_notified[com_name] = int(time.time())
 
@@ -113,7 +117,7 @@ def sendAppriseNotifications(sci_name, com_name, confidence, confidencepct, path
         if 0 < numberDetections <= 5:
             reason = f"only seen {numberDetections} times in last 7d"
             notify_body = render_template(body, reason)
-            notify_title = render_template(title, reason)
+            notify_title = "" if json_body else render_template(title, reason)
             notify(notify_body, notify_title, image_url)
             species_last_notified[com_name] = int(time.time())
 

--- a/tests/test_apprise_notifications.py
+++ b/tests/test_apprise_notifications.py
@@ -134,6 +134,35 @@ class TestAppriseNotifications(unittest.TestCase):
 
     @patch('scripts.utils.helpers._load_settings')
     @patch('scripts.utils.notifications.notify')
+    def test_json_body_preserves_quotes(self, mock_notify, mock_load_settings):
+        self.create_test_db()
+        # HTML entities can end up in body.txt via the settings UI; they must be
+        # unescaped, and JSON bodies must not get a title (MQTT prepends it).
+        with open(self.apprise_body_file, 'w') as f:
+            f.write('{&#34;Common_Name&#34;: &#34;$comname&#34;, &#34;Scientific_Name&#34;: &#34;$sciname&#34;, '
+                    '&#34;Confidence_Score&#34;: &#34;$confidence&#34;}')
+        with open(self.apprise_config_file, 'w') as f:
+            f.write('a dummy config')
+        notifications.APPRISE_BODY = self.apprise_body_file
+        notifications.APPRISE_CONFIG = self.apprise_config_file
+        notifications.DB_PATH = self.db_file
+        settings_dict = Settings.with_defaults()
+        settings_dict["APPRISE_NOTIFY_EACH_DETECTION"] = "1"
+        mock_load_settings.return_value = settings_dict
+
+        sendAppriseNotifications(**self.get_default_params())
+
+        self.assertEqual(mock_notify.call_count, 1)
+        body, title = mock_notify.call_args_list[0][0][0], mock_notify.call_args_list[0][0][1]
+        self.assertEqual(
+            body,
+            '{"Common_Name": "Great Crested Flycatcher", "Scientific_Name": "Myiarchus crinitus", '
+            '"Confidence_Score": "0.91"}'
+        )
+        self.assertEqual(title, "")
+
+    @patch('scripts.utils.helpers._load_settings')
+    @patch('scripts.utils.notifications.notify')
     def test_notifications_excluded(self, mock_notify, mock_load_settings):
         self.create_test_db()
         self.create_apprise_config()


### PR DESCRIPTION
## Summary
- Unescape HTML entities (e.g. `&#34;`) when reading the Apprise notification body so JSON payloads keep real quotes instead of entities.
- Omit the notification title when the body is JSON, because title-less services like MQTT prepend the title and break the payload.
- Harden the settings UI round-trip for the body (`html_entity_decode` on save/test, `htmlspecialchars` when rendering the textarea) and add a regression test.

## Test plan
- [ ] Set Apprise body to a JSON template with quoted fields (e.g. `{"Common_Name": "$comname", ...}`) and an `mqtt://` destination
- [ ] Update Settings, then Send Test Notification
- [ ] Confirm the MQTT payload is valid JSON with real `"` characters and no prepended title
- [ ] Confirm a normal (non-JSON) text body still includes the title as before
- [ ] Run `python -m unittest tests.test_apprise_notifications`


Made with [Cursor](https://cursor.com)